### PR TITLE
fix(CMakeLists.txt): add fPIC compile option

### DIFF
--- a/data_tamer/CMakeLists.txt
+++ b/data_tamer/CMakeLists.txt
@@ -21,6 +21,7 @@ else()
         -Wnon-virtual-dtor -Wno-unused-variable -Wnull-dereference -Wold-style-cast
         -Woverloaded-virtual -Wshadow -Wsign-conversion
         -Werror -Wpedantic)
+    add_compile_options(-fPIC)
 endif()
 
 


### PR DESCRIPTION
Hello @facontidavide , thanks for your great tool!

I recently tried out this tool an it works well!

As I was compiling it with the Autoware, I had some linker errors, you can see my struggle in https://www.twitch.tv/videos/1992007721?t=04h42m28s

In the end, for some reason, when I added `-fPIC` flag to the `data_tamer` package, the linker error was resolved.

I am not very good at cmake configuration and overall compiler flags. So I don't have the full understanding of the situation.

In the [nebula](https://github.com/tier4/nebula) driver, we use `ament_auto_find_build_dependencies()` and `ament_auto_add_library()` functions.

In my small test, I've simply added `<depend>data_tamer</depend>` to the `package.xml` so, this might help reproducing on a smaller scale too.

**Edit:** Just to be clear, it compiles, links and functions well with this change applied.