### PR TITLE
Fix compile error

### DIFF
--- a/data_tamer_cpp/include/data_tamer/details/locked_reference.hpp
+++ b/data_tamer_cpp/include/data_tamer/details/locked_reference.hpp
@@ -57,7 +57,7 @@ inline LockedPtr<T>::LockedPtr(LockedPtr&& other) : mutex_(other.mutex_)
 template <typename T>
 inline LockedPtr<T>& LockedPtr<T>::operator=(LockedPtr<T>&& other)
 {
-  mutex_ = &other.mutex_;
+  mutex_ = other.mutex_;
   std::swap(obj_, other.obj_);
   return *this;
 }


### PR DESCRIPTION
With master I get the following compile error (using CMake 3.30.2 and GCC 14.2.1 on Linux):
```
$ cmake --build build/Debug --parallel
[  5%] Building CXX object CMakeFiles/data_tamer.dir/src/sinks/mcap_sink.cpp.o
[ 10%] Building CXX object CMakeFiles/data_tamer.dir/src/data_tamer.cpp.o
[ 15%] Building CXX object CMakeFiles/data_tamer.dir/src/channel.cpp.o
[ 20%] Building CXX object CMakeFiles/data_tamer.dir/src/data_sink.cpp.o
[ 25%] Building CXX object CMakeFiles/data_tamer.dir/src/types.cpp.o
In file included from /home/daniel/git/data_tamer/data_tamer_cpp/include/data_tamer/logged_value.hpp:4,
                 from /home/daniel/git/data_tamer/data_tamer_cpp/include/data_tamer/channel.hpp:6,
                 from /home/daniel/git/data_tamer/data_tamer_cpp/src/channel.cpp:1:
/home/daniel/git/data_tamer/data_tamer_cpp/include/data_tamer/details/locked_reference.hpp: In member function ‘DataTamer::LockedPtr<T>& DataTamer::LockedPtr<T>::operator=(DataTamer::LockedPtr<T>&&)’:
/home/daniel/git/data_tamer/data_tamer_cpp/include/data_tamer/details/locked_reference.hpp:60:12: error: cannot convert ‘DataTamer::Mutex**’ to ‘DataTamer::Mutex*’ in assignment
   60 |   mutex_ = &other.mutex_;
      |            ^~~~~~~~~~~~~
      |            |
      |            DataTamer::Mutex**
In file included from /home/daniel/git/data_tamer/data_tamer_cpp/include/data_tamer/logged_value.hpp:4,
                 from /home/daniel/git/data_tamer/data_tamer_cpp/include/data_tamer/channel.hpp:6,
                 from /home/daniel/git/data_tamer/data_tamer_cpp/include/data_tamer/data_tamer.hpp:3,
                 from /home/daniel/git/data_tamer/data_tamer_cpp/src/data_tamer.cpp:1:
/home/daniel/git/data_tamer/data_tamer_cpp/include/data_tamer/details/locked_reference.hpp: In member function ‘DataTamer::LockedPtr<T>& DataTamer::LockedPtr<T>::operator=(DataTamer::LockedPtr<T>&&)’:
/home/daniel/git/data_tamer/data_tamer_cpp/include/data_tamer/details/locked_reference.hpp:60:12: error: cannot convert ‘DataTamer::Mutex**’ to ‘DataTamer::Mutex*’ in assignment
   60 |   mutex_ = &other.mutex_;
      |            ^~~~~~~~~~~~~
      |            |
      |            DataTamer::Mutex**
make[2]: *** [CMakeFiles/data_tamer.dir/build.make:90: CMakeFiles/data_tamer.dir/src/data_tamer.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/data_tamer.dir/build.make:76: CMakeFiles/data_tamer.dir/src/channel.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:154: CMakeFiles/data_tamer.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

It seems the issue was introduced in #18. I'm a bit confused how it wasn't discovered in all this time, doesn't seem like it should be compiler-dependent? Anyway the fix was simple.