### PR TITLE
Fix codecov to ignore 3rdparty folder

### DIFF
--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -56,8 +56,8 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       with:
-        directory: ${{github.workspace}}/build
-        gcov_ignore: ${{github.workspace}}/3rdparty
+        directory: ${{github.workspace}}/build/Testing
+        gcov_ignore: concurrentqueue.h
         verbose: true
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
It looks like we're trying to ignore codecov for the 3rd party folder, but it's included nonetheless. This PR fixes that to get a more accurate codecov value

Currently:
![image](https://github.com/user-attachments/assets/e73c8012-890d-4706-81b5-4622879f9ab6)

After this PR:
[trying to get codecov to cooperate]