### PR TITLE
Add Ubuntu 24.04 to CI

### DIFF
--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu 24.04]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Simple PR to add 24.04 to the matrix for the cmake ubuntu CI job.