### PR TITLE
Fixes 24.04 CI

### DIFF
--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -21,10 +21,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # ubuntu 24.04 doesn't allow non-user pip install anymore
-    - name: pip user install
+    # ubuntu 24.04 doesn't allow non-user pip install by default anymore
+    # don't do this on your host computer, but this is fine in CI
+    - name: pip break system packages
       if: matrix.os == 'ubuntu-24.04'
-      run: pip config set global.user true
+      run: export PIP_BREAK_SYSTEM_PACKAGES=1
 
     - name: Install Conan
       id: conan

--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
     # don't do this on your host computer, but this is fine in CI
     - name: pip break system packages
       if: matrix.os == 'ubuntu-24.04'
-      run: export PIP_BREAK_SYSTEM_PACKAGES=1
+      run: python3 -m pip config set global.break-system-packages true
 
     - name: Install Conan
       id: conan

--- a/.github/workflows/cmake_ubuntu.yml
+++ b/.github/workflows/cmake_ubuntu.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    # ubuntu 24.04 doesn't allow non-user pip install anymore
+    - name: pip user install
+      if: matrix.os == 'ubuntu-24.04'
+      run: pip config set global.user true
+
     - name: Install Conan
       id: conan
       uses: turtlebrowser/get-conan@main


### PR DESCRIPTION
24.04 no longer allows global pip installs. This adds a step to CI that (for 24.04 only) makes pip default to user installation.