### PR TITLE
Allow endless recording

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast

--- a/data_tamer_cpp/include/data_tamer/sinks/mcap_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/mcap_sink.hpp
@@ -25,7 +25,7 @@ public:
    * @brief MCAPSink.
    * IMPORTANT: if you want the recorder to be more robust to crash/segfault,
    * set `do_compression` to false.
-   * Compression is dafe if your application is closing cleanly.
+   * Compression is safe if your application is closing cleanly.
    *
    * @param filepath   path of the file to be saved. Should have extension ".mcap"
    * @param do_compression if true, compress the data on the fly.
@@ -40,6 +40,8 @@ public:
 
   /// After a certain amount of time, the MCAP file will be reset
   /// and overwritten. Default value is 600 seconds (10 minutes)
+  /// To disable this feature, use a time of 0 seconds.
+  /// WARNING: this can consume a large amount of disk space very quickly.
   void setMaxTimeBeforeReset(std::chrono::seconds reset_time);
 
   /// Stop recording and save the file
@@ -67,6 +69,7 @@ private:
   std::chrono::system_clock::time_point start_time_;
 
   bool forced_stop_recording_ = false;
+  bool unlimited_recording_ = false;
   std::recursive_mutex mutex_;
 
   void openFile(std::string const& filepath);

--- a/data_tamer_cpp/include/data_tamer/sinks/mcap_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/mcap_sink.hpp
@@ -69,7 +69,6 @@ private:
   std::chrono::system_clock::time_point start_time_;
 
   bool forced_stop_recording_ = false;
-  bool unlimited_recording_ = false;
   std::recursive_mutex mutex_;
 
   void openFile(std::string const& filepath);

--- a/data_tamer_cpp/src/sinks/mcap_sink.cpp
+++ b/data_tamer_cpp/src/sinks/mcap_sink.cpp
@@ -1,6 +1,7 @@
 #include "data_tamer/sinks/mcap_sink.hpp"
 #include "data_tamer/contrib/SerializeMe.hpp"
 
+#include <chrono>
 #include <sstream>
 #include <mutex>
 
@@ -118,7 +119,7 @@ bool MCAPSink::storeSnapshot(const Snapshot& snapshot)
   // If reset_time_ is exceeded, we want to overwrite the current file.
   // Better than filling the disk, if you forgot to stop the application.
   auto const now = std::chrono::system_clock::now();
-  if(now - start_time_ > reset_time_)
+  if(reset_time_ != std::chrono::seconds(0) && now - start_time_ > reset_time_)
   {
     restartRecording(filepath_, compression_);
   }


### PR DESCRIPTION
Resolves #31 and doesn't require users to change their usage really at all, just adds 0 as a sentinel value.

Also takes care of this issue I saw in pre-commit:
```
[WARNING] repo `https://github.com/pre-commit/pre-commit-hooks` uses deprecated stage names (commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks` will fix this.  if it does not -- consider reporting an issue to that repo.
```

My question regarding this change is: should we have the default reset time be 0? As mentioned in #31, I can understand wanting a different default behavior. I also understand not wanting to fill the disk super quickly though, especially since there's no way to ensure a user sees a warning in the docstring. I am open to other suggestions on this, but thought I'd make this PR just to start discussion.

Some other possibilities I considered:
- Still reset the recording, but with incrementing filenames (as mentioned in #31). Though this is easy to do, I opted to make the PR as-is since it is the smallest code change.
- Change the default to 'swap' between two recordings, so you have at most 2x reset_time of data used. This way, when you reset, you don't just delete all the data. You always have at least the last `reset_time` data saved. Perhaps a more forgiving default behavior, but maybe a little odd