### PR TITLE
Remove ament_target_dependencies usage

### DIFF
--- a/data_tamer_cpp/CMakeLists.txt
+++ b/data_tamer_cpp/CMakeLists.txt
@@ -104,7 +104,23 @@ if (DATA_TAMER_BUILD_ROS)
     find_package(rclcpp_lifecycle REQUIRED)
     find_package(data_tamer_msgs REQUIRED)
 
-    ament_target_dependencies(data_tamer mcap_vendor rclcpp rclcpp_lifecycle data_tamer_msgs)
+    target_include_directories(data_tamer PUBLIC
+        ${mcap_vendor_INCLUDE_DIRS}
+        ${rclcpp_INCLUDE_DIRS}
+        ${rclcpp_lifecycle_INCLUDE_DIRS}
+        ${data_tamer_msgs_INCLUDE_DIRS}
+    )
+
+    # we need to find the underlying library for `target_link_libraries` to work
+    find_library(MCAP_LIBRARY mcap PATHS ${mcap_vendor_LIBRARY_DIRS})
+
+    target_link_libraries(data_tamer PUBLIC
+        ${mcap_vendor_LIBRARIES}
+        ${rclcpp_LIBRARIES}
+        ${rclcpp_lifecycle_LIBRARIES}
+        ${data_tamer_msgs_LIBRARIES}
+        ${MCAP_LIBRARY}
+    )
 
     ament_export_targets(data_tamerTargets HAS_LIBRARY_TARGET)
     ament_export_dependencies(mcap_vendor rclcpp rclcpp_lifecycle data_tamer_msgs)

--- a/data_tamer_cpp/examples/CMakeLists.txt
+++ b/data_tamer_cpp/examples/CMakeLists.txt
@@ -18,7 +18,13 @@ target_include_directories(mcap_reader
 # optionally build for ROS 2
 option(DATA_TAMER_BUILD_ROS "Build for ROS 2" ON)
 if ( DATA_TAMER_BUILD_ROS AND ament_cmake_FOUND )
-    ament_target_dependencies(mcap_reader mcap_vendor)
+    target_include_directories(mcap_reader PUBLIC
+        ${mcap_vendor_INCLUDE_DIRS}
+    )
+    target_link_libraries(mcap_reader
+        data_tamer
+        ${mcap_vendor_LIBRARIES}
+    )
 
     CompileExample(ros2_publisher)
 


### PR DESCRIPTION
I think it's going to be deprecated soon and it's causing build farm problems:
[1](https://build.ros2.org/job/Rbin_unv8_uNv8__data_tamer_cpp__ubuntu_noble_arm64__binary/108/console)
[2](https://build.ros2.org/job/Rbin_uN64__data_tamer_cpp__ubuntu_noble_amd64__binary/112/console)
[3](https://build.ros2.org/job/Rbin_unv8_uNv8__data_tamer_cpp__ubuntu_noble_arm64__binary/107/)