### PR TITLE
adds missing zstd and lz4 deps that mcap lib needs

### DIFF
--- a/data_tamer_cpp/CMakeLists.txt
+++ b/data_tamer_cpp/CMakeLists.txt
@@ -7,6 +7,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
+# Find system dependencies for mcap
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(ZSTD REQUIRED libzstd)
+pkg_check_modules(LZ4 REQUIRED liblz4)
+
 if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
     option(DATA_TAMER_BUILD_TESTS "Build tests" ON)
     option(DATA_TAMER_BUILD_EXAMPLES "Build examples" ON)
@@ -34,6 +39,15 @@ find_package(mcap QUIET)
 if(NOT mcap_FOUND AND NOT DATA_TAMER_BUILD_ROS)
     set(USE_VENDORED_MCAP ON)
     message(STATUS "MCAP from 3rdparty")
+    
+    # Pass pkg-config variables to mcap subdirectory
+    set(ZSTD_INCLUDE_DIR ${ZSTD_INCLUDE_DIRS})
+    set(ZSTD_LIBRARY ${ZSTD_LIBRARIES})
+    set(ZSTD_FOUND TRUE)
+    set(LZ4_INCLUDE_DIR ${LZ4_INCLUDE_DIRS})
+    set(LZ4_LIBRARY ${LZ4_LIBRARIES})
+    set(LZ4_FOUND TRUE)
+    
     add_subdirectory(3rdparty/mcap)
     set(mcap_LIBRARY mcap_lib)
 else()

--- a/data_tamer_cpp/CMakeLists.txt
+++ b/data_tamer_cpp/CMakeLists.txt
@@ -8,9 +8,33 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 # Find system dependencies for mcap
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(ZSTD REQUIRED libzstd)
-pkg_check_modules(LZ4 REQUIRED liblz4)
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+    pkg_check_modules(ZSTD REQUIRED libzstd)
+    pkg_check_modules(LZ4 REQUIRED liblz4)
+else()
+    # Fallback: try to find libraries manually
+    find_library(ZSTD_LIBRARY NAMES zstd libzstd)
+    find_path(ZSTD_INCLUDE_DIR NAMES zstd.h)
+    find_library(LZ4_LIBRARY NAMES lz4 liblz4)
+    find_path(LZ4_INCLUDE_DIR NAMES lz4.h)
+    
+    if(ZSTD_LIBRARY AND ZSTD_INCLUDE_DIR)
+        set(ZSTD_FOUND TRUE)
+        set(ZSTD_LIBRARIES ${ZSTD_LIBRARY})
+        set(ZSTD_INCLUDE_DIRS ${ZSTD_INCLUDE_DIR})
+    endif()
+    
+    if(LZ4_LIBRARY AND LZ4_INCLUDE_DIR)
+        set(LZ4_FOUND TRUE)
+        set(LZ4_LIBRARIES ${LZ4_LIBRARY})
+        set(LZ4_INCLUDE_DIRS ${LZ4_INCLUDE_DIR})
+    endif()
+    
+    if(NOT ZSTD_FOUND OR NOT LZ4_FOUND)
+        message(FATAL_ERROR "Could not find ZSTD or LZ4 libraries. Please install libzstd-dev and liblz4-dev packages.")
+    endif()
+endif()
 
 if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
     option(DATA_TAMER_BUILD_TESTS "Build tests" ON)


### PR DESCRIPTION
in a client repo that uses data_tamer as a thirdparty submodule the CI fails with 

>   CMake Error at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
>     Could NOT find ZSTD (missing: ZSTD_LIBRARY ZSTD_INCLUDE_DIR)
>   Call Stack (most recent call first):
>     /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
>     dependencies/data_tamer/data_tamer_cpp/3rdparty/mcap/cmake/FindZSTD.cmake:32 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
>     dependencies/data_tamer/data_tamer_cpp/3rdparty/mcap/CMakeLists.txt:4 (find_package)
>   
>   ---
>   Failed   <<< f_libs [36.6s, exited with code 1]
>   Aborted  <<< f_msgs [36.6s]

this pr tries to resolve the cmake's error in not finding ZSTD!