### PR TITLE
Inline operator== function to prevent multiple includes

### DIFF
--- a/data_tamer_cpp/include/data_tamer_parser/data_tamer_parser.hpp
+++ b/data_tamer_cpp/include/data_tamer_parser/data_tamer_parser.hpp
@@ -207,7 +207,7 @@ inline bool GetBit(BufferSpan mask, size_t index)
   return hash;
 }
 
-bool TypeField::operator==(const TypeField& other) const
+inline bool TypeField::operator==(const TypeField& other) const
 {
   return is_vector == other.is_vector && type == other.type &&
          array_size == other.array_size && field_name == other.field_name &&


### PR DESCRIPTION
It looks like the `operator==` in needed to be inline'd since it's declared and defined in the header to prevent multiple includes