### PR TITLE
Add thread-safe methods to add and remove data sinks in LogChannel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # This file is used to ignore files which are generated
 # ----------------------------------------------------------------------------
-
+.vscode
 *~
 *.autosave
 *.a

--- a/data_tamer_cpp/include/data_tamer/channel.hpp
+++ b/data_tamer_cpp/include/data_tamer/channel.hpp
@@ -154,6 +154,11 @@ public:
   void addDataSink(std::shared_ptr<DataSinkBase> sink);
 
   /**
+   * @brief removeDataSink remove a sink, i.e. a class collecting our snapshots.
+   */
+  void removeDataSink(std::shared_ptr<DataSinkBase> sink);
+
+  /**
    * @brief takeSnapshot copies the current value of all your registered values
    *  and send an instance of Snapshot to all your Sinks.
    *

--- a/data_tamer_cpp/include/data_tamer/channel.hpp
+++ b/data_tamer_cpp/include/data_tamer/channel.hpp
@@ -159,6 +159,11 @@ public:
   void removeDataSink(std::shared_ptr<DataSinkBase> sink);
 
   /**
+  * @brief getNumberOfSink returns the number of registered sinks.
+  */
+  size_t getNumberOfSinks() const;
+
+  /**
    * @brief takeSnapshot copies the current value of all your registered values
    *  and send an instance of Snapshot to all your Sinks.
    *

--- a/data_tamer_cpp/include/data_tamer/channel.hpp
+++ b/data_tamer_cpp/include/data_tamer/channel.hpp
@@ -86,8 +86,9 @@ public:
    * @param value  pointer to the vectors of values.
    * @return       the ID to be used to unregister or enable/disable the values.
    */
-  template <template <class, class> class Container, class T, class... TArgs,
-            std::enable_if_t<!has_TypeDefinition<Container<T, TArgs...>>::value, bool> = true>
+  template <
+      template <class, class> class Container, class T, class... TArgs,
+      std::enable_if_t<!has_TypeDefinition<Container<T, TArgs...>>::value, bool> = true>
   RegistrationID registerValue(const std::string& name,
                                const Container<T, TArgs...>* value);
 
@@ -159,7 +160,7 @@ public:
   void removeDataSink(std::shared_ptr<DataSinkBase> sink);
 
   /**
-  * @brief getNumberOfSink returns the number of registered sinks.
+  * @brief getNumberOfSinks returns the number of registered sinks.
   */
   size_t getNumberOfSinks() const;
 

--- a/data_tamer_cpp/src/channel.cpp
+++ b/data_tamer_cpp/src/channel.cpp
@@ -163,15 +163,13 @@ void LogChannel::addDataSink(std::shared_ptr<DataSinkBase> sink)
 {
   std::lock_guard const lock_sinks(_p->sinks_mutex);
 
-  if(!_p->logging_started)
-  {
-    _p->sinks.insert(sink);
-  }
-  else
+  // if we haven't already started logging, then takeSnapshot() handles adding the channel
+  // otherwise it must be done here so the sink knows about the existing schema
+  if(_p->logging_started)
   {
     sink->addChannel(_p->channel_name, _p->schema);
-    _p->sinks.insert(sink);
   }
+  _p->sinks.insert(sink);
 }
 
 void LogChannel::removeDataSink(std::shared_ptr<DataSinkBase> sink)

--- a/data_tamer_cpp/src/channel.cpp
+++ b/data_tamer_cpp/src/channel.cpp
@@ -240,13 +240,14 @@ bool LogChannel::takeSnapshot(std::chrono::nanoseconds timestamp)
     }
     _p->snapshot.payload.resize(payload_size);
 
-    // call sink->addChannel (usually done once)
+    // set up the channel if we haven't begun logging
     if(!_p->logging_started)
     {
-      _p->logging_started = true;
       _p->snapshot.schema_hash = _p->schema.hash;
 
       std::lock_guard const lock_sinks(_p->sinks_mutex);
+      // start logging inside the sinks_mutex so that addDataSink does not have an incorrect value due to a race condition
+      _p->logging_started = true;
       for(auto const& sink : _p->sinks)
       {
         sink->addChannel(_p->channel_name, _p->schema);

--- a/data_tamer_cpp/src/channel.cpp
+++ b/data_tamer_cpp/src/channel.cpp
@@ -180,6 +180,12 @@ void LogChannel::removeDataSink(std::shared_ptr<DataSinkBase> sink)
   _p->sinks.erase(sink);
 }
 
+size_t LogChannel::getNumberOfSinks() const
+{
+  std::lock_guard const lock(_p->sinks_mutex);
+  return _p->sinks.size();
+}
+
 Schema LogChannel::getSchema() const
 {
   std::lock_guard const lock(_p->mutex);

--- a/data_tamer_cpp/tests/CMakeLists.txt
+++ b/data_tamer_cpp/tests/CMakeLists.txt
@@ -28,7 +28,8 @@ else()
     add_executable(datatamer_test
         dt_tests.cpp
         custom_types_tests.cpp
-        parser_tests.cpp)
+        parser_tests.cpp
+        add_remove_sink_tests.cpp)
     gtest_discover_tests(datatamer_test DISCOVERY_MODE PRE_TEST)
 
     target_include_directories(datatamer_test

--- a/data_tamer_cpp/tests/add_remove_sink_tests.cpp
+++ b/data_tamer_cpp/tests/add_remove_sink_tests.cpp
@@ -1,0 +1,71 @@
+#include "data_tamer/channel.hpp"
+#include "data_tamer/sinks/dummy_sink.hpp"
+
+#include <gtest/gtest.h>
+#include <string>
+#include <thread>
+
+using namespace DataTamer;
+
+void take_snapshots(std::shared_ptr<LogChannel> channel, int count)
+{
+  for(int i = 0; i < count; i++)
+  {
+    channel->takeSnapshot();
+    std::this_thread::sleep_for(std::chrono::microseconds(50));
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+}
+
+TEST(DataTamerSinkRegistry, AddSinkIncreasesCountAndRef)
+{
+  auto channel = LogChannel::create("chan");
+  auto sink = std::make_shared<DummySink>();
+  channel->addDataSink(sink);
+
+  std::vector<double> dummyData = { 10, 11, 12 };
+  channel->registerValue("valsA", &dummyData);
+
+  ASSERT_EQ(channel->getNumberOfSinks(), 1);
+}
+
+TEST(DataTamerSinkRegistry, SnapshotsAreRecordedWhileSinkPresent)
+{
+  auto channel = LogChannel::create("chan");
+  auto sink = std::make_shared<DummySink>();
+  channel->addDataSink(sink);
+
+  std::vector<double> dummyData = { 10, 11, 12 };
+  channel->registerValue("valsA", &dummyData);
+
+  const int snapshot_count = 10;
+  take_snapshots(channel, snapshot_count);
+
+  const auto hash = channel->getSchema().hash;
+  ASSERT_EQ(sink->snapshots_count[hash], snapshot_count);
+}
+
+TEST(DataTamerSinkRegistry, RemoveSinkStopsRecording)
+{
+  auto channel = LogChannel::create("chan");
+  auto sink = std::make_shared<DummySink>();
+  channel->addDataSink(sink);
+
+  std::vector<double> dummyData = { 10, 11, 12 };
+  channel->registerValue("valsA", &dummyData);
+
+  const int snapshot_count = 10;
+  take_snapshots(channel, snapshot_count);
+
+  const auto hash = channel->getSchema().hash;
+  ASSERT_EQ(sink->snapshots_count[hash], snapshot_count);
+
+  channel->removeDataSink(sink);
+
+  ASSERT_EQ(channel->getNumberOfSinks(), 0);
+
+  // Taking more snapshots, should not be recorded in the sink (i.e does not increase snapshots_count)
+  take_snapshots(channel, snapshot_count);
+
+  ASSERT_EQ(sink->snapshots_count[hash], snapshot_count);
+}


### PR DESCRIPTION
### Summary

This PR aims to provide the ability to add and remove sinks from data channels at runtime. It introduces thread-safe methods for remove and add data sinks in the `LogChannel` class. 

### Impact
- No breaking changes to the public API.
- This update allows users to dynamically add and remove data sinks from a channel at runtime. This is especially useful for scenarios where data needs to be recorded/streamed temporarily on specific channels for short durations.


**Please review the changes and provide feedback.** :pray: 