### PR TITLE
Update ROS 2 publisher sink to use NodeInterfaces

### DIFF
--- a/data_tamer_cpp/examples/ros2_publisher.cpp
+++ b/data_tamer_cpp/examples/ros2_publisher.cpp
@@ -10,7 +10,7 @@ int main(int argc, char* argv[])
   rclcpp::init(argc, argv);
   auto node = std::make_shared<rclcpp::Node>("test_datatamer");
 
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(*node, "test");
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(node, "test");
   ChannelsRegistry::Global().addDefaultSink(ros2_sink);
 
   // Create (or get) a channel using the global registry (singleton)

--- a/data_tamer_cpp/examples/ros2_publisher.cpp
+++ b/data_tamer_cpp/examples/ros2_publisher.cpp
@@ -10,7 +10,7 @@ int main(int argc, char* argv[])
   rclcpp::init(argc, argv);
   auto node = std::make_shared<rclcpp::Node>("test_datatamer");
 
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(node, "test");
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(*node, "test");
   ChannelsRegistry::Global().addDefaultSink(ros2_sink);
 
   // Create (or get) a channel using the global registry (singleton)

--- a/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
@@ -6,21 +6,25 @@
 #include "data_tamer_msgs/msg/snapshot.hpp"
 #include <unordered_map>
 #include <rclcpp/rclcpp.hpp>
-#include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <rclcpp/node_interfaces/node_interfaces.hpp>
+#include <rclcpp/node_interfaces/node_topics_interface.hpp>
 
 namespace DataTamer
 {
 
+using PublisherNodeInterfaces =
+    rclcpp::node_interfaces::NodeInterfaces<rclcpp::node_interfaces::NodeTopicsInterface>;
+
 class ROS2PublisherSink : public DataSinkBase
 {
 public:
-  ROS2PublisherSink(std::shared_ptr<rclcpp::Node> node, const std::string& topic_prefix);
+  ROS2PublisherSink(PublisherNodeInterfaces& interfaces, const std::string& topic_prefix)
+    : interfaces_(interfaces)
+  {
+    create_publishers(topic_prefix);
+  }
 
-  ROS2PublisherSink(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-                    const std::string& topic_prefix);
-
-  template <typename NodeT>
-  void create_publishers(NodeT& node, const std::string& topic_prefix)
+  void create_publishers(const std::string& topic_prefix)
   {
     rclcpp::QoS schemas_qos{ rclcpp::KeepAll() };
     schemas_qos.reliable();
@@ -28,10 +32,10 @@ public:
 
     const rclcpp::QoS data_qos{ rclcpp::KeepAll() };
 
-    schema_publisher_ = node->template create_publisher<data_tamer_msgs::msg::Schemas>(
-        topic_prefix + "/schemas", schemas_qos);
-    data_publisher_ = node->template create_publisher<data_tamer_msgs::msg::Snapshot>(
-        topic_prefix + "/data", data_qos);
+    schema_publisher_ = rclcpp::create_publisher<data_tamer_msgs::msg::Schemas>(
+        interfaces_, topic_prefix + "/schemas", schemas_qos);
+    data_publisher_ = rclcpp::create_publisher<data_tamer_msgs::msg::Snapshot>(
+        interfaces_, topic_prefix + "/data", data_qos);
   }
 
   void addChannel(const std::string& name, const Schema& schema) override;
@@ -47,6 +51,9 @@ private:
 
   bool schema_changed_ = true;
   data_tamer_msgs::msg::Snapshot data_msg_;
+
+  // ---- Stored node façade ----
+  PublisherNodeInterfaces& interfaces_;
 };
 
 }  // namespace DataTamer

--- a/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
@@ -7,7 +7,7 @@
 #include <unordered_map>
 #include <type_traits>
 #include <rclcpp/rclcpp.hpp>
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <rclcpp/node_interfaces/node_interfaces.hpp>
 #include <rclcpp/node_interfaces/node_topics_interface.hpp>
 

--- a/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
@@ -18,7 +18,7 @@ using PublisherNodeInterfaces =
 class ROS2PublisherSink : public DataSinkBase
 {
 public:
-  ROS2PublisherSink(PublisherNodeInterfaces& interfaces, const std::string& topic_prefix)
+  ROS2PublisherSink(PublisherNodeInterfaces interfaces, const std::string& topic_prefix)
     : interfaces_(interfaces)
   {
     create_publishers(topic_prefix);
@@ -53,7 +53,7 @@ private:
   data_tamer_msgs::msg::Snapshot data_msg_;
 
   // ---- Stored node façade ----
-  PublisherNodeInterfaces& interfaces_;
+  PublisherNodeInterfaces interfaces_;
 };
 
 }  // namespace DataTamer

--- a/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
@@ -19,7 +19,7 @@ class ROS2PublisherSink : public DataSinkBase
 {
 public:
   ROS2PublisherSink(PublisherNodeInterfaces interfaces, const std::string& topic_prefix)
-    : interfaces_(interfaces)
+    : interfaces_(std::move(interfaces))
   {
     create_publishers(topic_prefix);
   }

--- a/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
@@ -15,11 +15,18 @@ namespace DataTamer
 using PublisherNodeInterfaces =
     rclcpp::node_interfaces::NodeInterfaces<rclcpp::node_interfaces::NodeTopicsInterface>;
 
+// Concept: allow Node, LifecycleNode, or NodeInterface
+template <typename NodeLike>
+concept NodeInterfaceType = std::same_as<NodeLike, rclcpp::Node> ||
+                            std::same_as<NodeLike, rclcpp_lifecycle::LifecycleNode> ||
+                            std::same_as<NodeLike, PublisherNodeInterfaces>;
+
 class ROS2PublisherSink : public DataSinkBase
 {
 public:
-  ROS2PublisherSink(PublisherNodeInterfaces interfaces, const std::string& topic_prefix)
-    : interfaces_(std::move(interfaces))
+  template <typename NodeType>
+  ROS2PublisherSink(NodeType interfaces, const std::string& topic_prefix)
+    : interfaces_(interfaces)
   {
     create_publishers(topic_prefix);
   }

--- a/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
@@ -27,20 +27,6 @@ public:
     create_publishers(topic_prefix);
   }
 
-  void create_publishers(const std::string& topic_prefix)
-  {
-    rclcpp::QoS schemas_qos{ rclcpp::KeepAll() };
-    schemas_qos.reliable();
-    schemas_qos.transient_local();  // latch
-
-    const rclcpp::QoS data_qos{ rclcpp::KeepAll() };
-
-    schema_publisher_ = rclcpp::create_publisher<data_tamer_msgs::msg::Schemas>(
-        node_interface_, topic_prefix + "/schemas", schemas_qos);
-    data_publisher_ = rclcpp::create_publisher<data_tamer_msgs::msg::Snapshot>(
-        node_interface_, topic_prefix + "/data", data_qos);
-  }
-
   void addChannel(const std::string& name, const Schema& schema) override;
 
   bool storeSnapshot(const Snapshot& snapshot) override;
@@ -58,6 +44,20 @@ private:
       return PublisherNodeInterfaces(*nodelike);
     else
       return PublisherNodeInterfaces(nodelike);
+  }
+
+  void create_publishers(const std::string& topic_prefix)
+  {
+    rclcpp::QoS schemas_qos{ rclcpp::KeepAll() };
+    schemas_qos.reliable();
+    schemas_qos.transient_local();  // latch
+
+    const rclcpp::QoS data_qos{ rclcpp::KeepAll() };
+
+    schema_publisher_ = rclcpp::create_publisher<data_tamer_msgs::msg::Schemas>(
+        node_interface_, topic_prefix + "/schemas", schemas_qos);
+    data_publisher_ = rclcpp::create_publisher<data_tamer_msgs::msg::Snapshot>(
+        node_interface_, topic_prefix + "/data", data_qos);
   }
 
   std::unordered_map<std::string, Schema> schemas_;

--- a/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
@@ -37,13 +37,31 @@ private:
   {
     using D = std::decay_t<NodeT>;
 
+    // use a friendlier compile error than the one that would otherwise come out
+    static_assert(
+        std::is_same_v<D, PublisherNodeInterfaces> ||
+            std::is_same_v<D, std::shared_ptr<rclcpp::Node>> ||
+            std::is_same_v<D, std::shared_ptr<rclcpp_lifecycle::LifecycleNode>> ||
+            std::is_constructible_v<PublisherNodeInterfaces, D&>,
+        "ROS2PublisherSink: unsupported node-like type passed to "
+        "`ROS2PublisherSink(NodeT&& nodelike, const std::string& topic_prefix)`. Pass a "
+        "rclcpp::Node, "
+        "rclcpp_lifecycle::LifecycleNode, a shared_ptr to either, or a "
+        "PublisherNodeInterfaces.");
+
     if constexpr(std::is_same_v<D, PublisherNodeInterfaces>)
+    {
       return nodelike;
+    }
     else if constexpr(std::is_same_v<D, std::shared_ptr<rclcpp::Node>> ||
                       std::is_same_v<D, std::shared_ptr<rclcpp_lifecycle::LifecycleNode>>)
+    {
       return PublisherNodeInterfaces(*nodelike);
+    }
     else
+    {
       return PublisherNodeInterfaces(nodelike);
+    }
   }
 
   void create_publishers(const std::string& topic_prefix)

--- a/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
@@ -5,7 +5,9 @@
 #include "data_tamer_msgs/msg/schemas.hpp"
 #include "data_tamer_msgs/msg/snapshot.hpp"
 #include <unordered_map>
+#include <type_traits>
 #include <rclcpp/rclcpp.hpp>
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include <rclcpp/node_interfaces/node_interfaces.hpp>
 #include <rclcpp/node_interfaces/node_topics_interface.hpp>
 
@@ -15,18 +17,12 @@ namespace DataTamer
 using PublisherNodeInterfaces =
     rclcpp::node_interfaces::NodeInterfaces<rclcpp::node_interfaces::NodeTopicsInterface>;
 
-// Concept: allow Node, LifecycleNode, or NodeInterface
-template <typename NodeLike>
-concept NodeInterfaceType = std::same_as<NodeLike, rclcpp::Node> ||
-                            std::same_as<NodeLike, rclcpp_lifecycle::LifecycleNode> ||
-                            std::same_as<NodeLike, PublisherNodeInterfaces>;
-
 class ROS2PublisherSink : public DataSinkBase
 {
 public:
-  template <typename NodeType>
-  ROS2PublisherSink(NodeType interfaces, const std::string& topic_prefix)
-    : interfaces_(interfaces)
+  template <typename NodeT>
+  ROS2PublisherSink(NodeT&& nodelike, const std::string& topic_prefix)
+    : node_interface_(normalize_node(nodelike))
   {
     create_publishers(topic_prefix);
   }
@@ -40,9 +36,9 @@ public:
     const rclcpp::QoS data_qos{ rclcpp::KeepAll() };
 
     schema_publisher_ = rclcpp::create_publisher<data_tamer_msgs::msg::Schemas>(
-        interfaces_, topic_prefix + "/schemas", schemas_qos);
+        node_interface_, topic_prefix + "/schemas", schemas_qos);
     data_publisher_ = rclcpp::create_publisher<data_tamer_msgs::msg::Snapshot>(
-        interfaces_, topic_prefix + "/data", data_qos);
+        node_interface_, topic_prefix + "/data", data_qos);
   }
 
   void addChannel(const std::string& name, const Schema& schema) override;
@@ -50,6 +46,20 @@ public:
   bool storeSnapshot(const Snapshot& snapshot) override;
 
 private:
+  template <typename NodeT>
+  static PublisherNodeInterfaces normalize_node(NodeT&& nodelike)
+  {
+    using D = std::decay_t<NodeT>;
+
+    if constexpr(std::is_same_v<D, PublisherNodeInterfaces>)
+      return nodelike;
+    else if constexpr(std::is_same_v<D, std::shared_ptr<rclcpp::Node>> ||
+                      std::is_same_v<D, std::shared_ptr<rclcpp_lifecycle::LifecycleNode>>)
+      return PublisherNodeInterfaces(*nodelike);
+    else
+      return PublisherNodeInterfaces(nodelike);
+  }
+
   std::unordered_map<std::string, Schema> schemas_;
   Mutex schema_mutex_;
 
@@ -60,7 +70,7 @@ private:
   data_tamer_msgs::msg::Snapshot data_msg_;
 
   // ---- Stored node façade ----
-  PublisherNodeInterfaces interfaces_;
+  PublisherNodeInterfaces node_interface_;
 };
 
 }  // namespace DataTamer

--- a/data_tamer_cpp/src/sinks/ros2_publisher_sink.cpp
+++ b/data_tamer_cpp/src/sinks/ros2_publisher_sink.cpp
@@ -2,18 +2,6 @@
 
 namespace DataTamer
 {
-ROS2PublisherSink::ROS2PublisherSink(std::shared_ptr<rclcpp::Node> node,
-                                     const std::string& topic_prefix)
-{
-  create_publishers(node, topic_prefix);
-}
-
-ROS2PublisherSink::ROS2PublisherSink(
-    std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node,
-    const std::string& topic_prefix)
-{
-  create_publishers(node, topic_prefix);
-}
 
 void ROS2PublisherSink::addChannel(const std::string& channel_name, const Schema& schema)
 {

--- a/data_tamer_cpp/tests/CMakeLists.txt
+++ b/data_tamer_cpp/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ if(gtest_vendor_FOUND AND ament_cmake_gtest_FOUND)
         dt_tests.cpp
         custom_types_tests.cpp
         parser_tests.cpp
+        ros2_publisher_tests.cpp
         trait_tests.cpp)
 
     target_include_directories(datatamer_test
@@ -28,6 +29,7 @@ else()
     add_executable(datatamer_test
         dt_tests.cpp
         custom_types_tests.cpp
+        ros2_publisher_tests.cpp
         parser_tests.cpp)
     gtest_discover_tests(datatamer_test DISCOVERY_MODE PRE_TEST)
 

--- a/data_tamer_cpp/tests/CMakeLists.txt
+++ b/data_tamer_cpp/tests/CMakeLists.txt
@@ -29,7 +29,6 @@ else()
     add_executable(datatamer_test
         dt_tests.cpp
         custom_types_tests.cpp
-        ros2_publisher_tests.cpp
         parser_tests.cpp)
     gtest_discover_tests(datatamer_test DISCOVERY_MODE PRE_TEST)
 

--- a/data_tamer_cpp/tests/ros2_publisher_tests.cpp
+++ b/data_tamer_cpp/tests/ros2_publisher_tests.cpp
@@ -79,6 +79,45 @@ TEST(DataTamerROS2Publisher, DereferenceLifeCycle)
   EXPECT_TRUE(channel->takeSnapshot());
 }
 
+TEST(DataTamerROS2Publisher, NodeInterfacesDirect)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_datatamer_node_interfaces");
+  PublisherNodeInterfaces interfaces(*node);
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(interfaces, "test_node_"
+                                                                   "interfaces");
+
+  auto channel = ChannelsRegistry::Global().getChannel("channel_node_interfaces");
+
+  channel->addDataSink(ros2_sink);
+
+  double const value = 1.;
+  auto id_value = channel->registerValue("value", &value);
+
+  EXPECT_TRUE(channel->takeSnapshot());
+}
+
+TEST(DataTamerROS2Publisher, NodeInterfacesDirectLifeCycle)
+{
+  auto lifecycle_node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_"
+                                                                          "datatamer_"
+                                                                          "node_"
+                                                                          "interfaces_"
+                                                                          "lifecycle");
+  PublisherNodeInterfaces interfaces(*lifecycle_node);
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(interfaces, "test_node_interfaces_"
+                                                                   "lifecycle");
+
+  auto channel = ChannelsRegistry::Global().getChannel("channel_node_interfaces_"
+                                                       "lifecycle");
+
+  channel->addDataSink(ros2_sink);
+
+  double const value = 1.;
+  auto id_value = channel->registerValue("value", &value);
+
+  EXPECT_TRUE(channel->takeSnapshot());
+}
+
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);

--- a/data_tamer_cpp/tests/ros2_publisher_tests.cpp
+++ b/data_tamer_cpp/tests/ros2_publisher_tests.cpp
@@ -42,6 +42,8 @@ TEST(DataTamerROS2Publisher, SharedPointerLifeCycle)
   auto id_value = channel->registerValue("value", &value);
 
   EXPECT_TRUE(channel->takeSnapshot());
+
+  lifecycle_node->shutdown();
 }
 
 TEST(DataTamerROS2Publisher, Dereference)
@@ -77,6 +79,8 @@ TEST(DataTamerROS2Publisher, DereferenceLifeCycle)
   auto id_value = channel->registerValue("value", &value);
 
   EXPECT_TRUE(channel->takeSnapshot());
+
+  lifecycle_node->shutdown();
 }
 
 TEST(DataTamerROS2Publisher, NodeInterfacesDirect)
@@ -116,6 +120,8 @@ TEST(DataTamerROS2Publisher, NodeInterfacesDirectLifeCycle)
   auto id_value = channel->registerValue("value", &value);
 
   EXPECT_TRUE(channel->takeSnapshot());
+
+  lifecycle_node->shutdown();
 }
 
 int main(int argc, char** argv)

--- a/data_tamer_cpp/tests/ros2_publisher_tests.cpp
+++ b/data_tamer_cpp/tests/ros2_publisher_tests.cpp
@@ -17,7 +17,7 @@ TEST(DataTamerROS2Publisher, SharedPointer)
   channel->addDataSink(ros2_sink);
 
   double const value = 1.;
-  auto id_value = channel->registerValue("value", &value);
+  channel->registerValue("value", &value);
 
   EXPECT_TRUE(channel->takeSnapshot());
 }
@@ -39,7 +39,7 @@ TEST(DataTamerROS2Publisher, SharedPointerLifeCycle)
   channel->addDataSink(ros2_sink);
 
   double const value = 1.;
-  auto id_value = channel->registerValue("value", &value);
+  channel->registerValue("value", &value);
 
   EXPECT_TRUE(channel->takeSnapshot());
 
@@ -56,7 +56,7 @@ TEST(DataTamerROS2Publisher, Dereference)
   channel->addDataSink(ros2_sink);
 
   double const value = 1.;
-  auto id_value = channel->registerValue("value", &value);
+  channel->registerValue("value", &value);
 
   EXPECT_TRUE(channel->takeSnapshot());
 }
@@ -76,7 +76,7 @@ TEST(DataTamerROS2Publisher, DereferenceLifeCycle)
   channel->addDataSink(ros2_sink);
 
   double const value = 1.;
-  auto id_value = channel->registerValue("value", &value);
+  channel->registerValue("value", &value);
 
   EXPECT_TRUE(channel->takeSnapshot());
 
@@ -95,7 +95,7 @@ TEST(DataTamerROS2Publisher, NodeInterfacesDirect)
   channel->addDataSink(ros2_sink);
 
   double const value = 1.;
-  auto id_value = channel->registerValue("value", &value);
+  channel->registerValue("value", &value);
 
   EXPECT_TRUE(channel->takeSnapshot());
 }
@@ -117,7 +117,7 @@ TEST(DataTamerROS2Publisher, NodeInterfacesDirectLifeCycle)
   channel->addDataSink(ros2_sink);
 
   double const value = 1.;
-  auto id_value = channel->registerValue("value", &value);
+  channel->registerValue("value", &value);
 
   EXPECT_TRUE(channel->takeSnapshot());
 

--- a/data_tamer_cpp/tests/ros2_publisher_tests.cpp
+++ b/data_tamer_cpp/tests/ros2_publisher_tests.cpp
@@ -1,13 +1,9 @@
 #include "data_tamer/data_tamer.hpp"
-#include "data_tamer/sinks/dummy_sink.hpp"
 #include "data_tamer/sinks/ros2_publisher_sink.hpp"
 
 #include <gtest/gtest.h>
 
-#include <filesystem>
-#include <variant>
 #include <string>
-#include <thread>
 
 using namespace DataTamer;
 

--- a/data_tamer_cpp/tests/ros2_publisher_tests.cpp
+++ b/data_tamer_cpp/tests/ros2_publisher_tests.cpp
@@ -1,0 +1,83 @@
+#include "data_tamer/data_tamer.hpp"
+#include "data_tamer/sinks/dummy_sink.hpp"
+#include "data_tamer/sinks/ros2_publisher_sink.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <variant>
+#include <string>
+#include <thread>
+
+using namespace DataTamer;
+
+TEST(DataTamerROS2Publisher, SharedPointer)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_datatamer");
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(node, "test");
+
+  auto channel = ChannelsRegistry::Global().getChannel("channel");
+
+  channel->addDataSink(ros2_sink);
+
+  double const value = 1.;
+  auto id_value = channel->registerValue("value", &value);
+
+  EXPECT_TRUE(channel->takeSnapshot());
+}
+
+TEST(DataTamerROS2Publisher, SharedPointerLifeCycle)
+{
+  auto lifecycle_node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_"
+                                                                          "datatamer");
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(lifecycle_node, "test");
+
+  auto channel = ChannelsRegistry::Global().getChannel("channel");
+
+  channel->addDataSink(ros2_sink);
+
+  double const value = 1.;
+  auto id_value = channel->registerValue("value", &value);
+
+  EXPECT_TRUE(channel->takeSnapshot());
+}
+
+TEST(DataTamerROS2Publisher, Dereference)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_datatamer");
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(*node, "test");
+
+  auto channel = ChannelsRegistry::Global().getChannel("channel");
+
+  channel->addDataSink(ros2_sink);
+
+  double const value = 1.;
+  auto id_value = channel->registerValue("value", &value);
+
+  EXPECT_TRUE(channel->takeSnapshot());
+}
+
+TEST(DataTamerROS2Publisher, DereferenceLifeCycle)
+{
+  auto lifecycle_node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_"
+                                                                          "datatamer");
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(*lifecycle_node, "test");
+
+  auto channel = ChannelsRegistry::Global().getChannel("channel");
+
+  channel->addDataSink(ros2_sink);
+
+  double const value = 1.;
+  auto id_value = channel->registerValue("value", &value);
+
+  EXPECT_TRUE(channel->takeSnapshot());
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/data_tamer_cpp/tests/ros2_publisher_tests.cpp
+++ b/data_tamer_cpp/tests/ros2_publisher_tests.cpp
@@ -13,10 +13,10 @@ using namespace DataTamer;
 
 TEST(DataTamerROS2Publisher, SharedPointer)
 {
-  auto node = std::make_shared<rclcpp::Node>("test_datatamer");
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(node, "test");
+  auto node = std::make_shared<rclcpp::Node>("test_datatamer_shared_pointer");
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(node, "test_shared_pointer");
 
-  auto channel = ChannelsRegistry::Global().getChannel("channel");
+  auto channel = ChannelsRegistry::Global().getChannel("channel_shared_pointer");
 
   channel->addDataSink(ros2_sink);
 
@@ -29,10 +29,16 @@ TEST(DataTamerROS2Publisher, SharedPointer)
 TEST(DataTamerROS2Publisher, SharedPointerLifeCycle)
 {
   auto lifecycle_node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_"
-                                                                          "datatamer");
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(lifecycle_node, "test");
+                                                                          "datatamer_"
+                                                                          "shared_"
+                                                                          "pointer_"
+                                                                          "lifecycle");
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(lifecycle_node, "test_shared_"
+                                                                       "pointer_"
+                                                                       "lifecycle");
 
-  auto channel = ChannelsRegistry::Global().getChannel("channel");
+  auto channel = ChannelsRegistry::Global().getChannel("channel_shared_pointer_"
+                                                       "lifecycle");
 
   channel->addDataSink(ros2_sink);
 
@@ -44,10 +50,10 @@ TEST(DataTamerROS2Publisher, SharedPointerLifeCycle)
 
 TEST(DataTamerROS2Publisher, Dereference)
 {
-  auto node = std::make_shared<rclcpp::Node>("test_datatamer");
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(*node, "test");
+  auto node = std::make_shared<rclcpp::Node>("test_datatamer_dereference");
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(*node, "test_dereference");
 
-  auto channel = ChannelsRegistry::Global().getChannel("channel");
+  auto channel = ChannelsRegistry::Global().getChannel("channel_dereference");
 
   channel->addDataSink(ros2_sink);
 
@@ -60,10 +66,14 @@ TEST(DataTamerROS2Publisher, Dereference)
 TEST(DataTamerROS2Publisher, DereferenceLifeCycle)
 {
   auto lifecycle_node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_"
-                                                                          "datatamer");
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(*lifecycle_node, "test");
+                                                                          "datatamer_"
+                                                                          "dereference_"
+                                                                          "lifecycle");
+  auto ros2_sink = std::make_shared<ROS2PublisherSink>(*lifecycle_node, "test_"
+                                                                        "dereference_"
+                                                                        "lifecycle");
 
-  auto channel = ChannelsRegistry::Global().getChannel("channel");
+  auto channel = ChannelsRegistry::Global().getChannel("channel_dereference_lifecycle");
 
   channel->addDataSink(ros2_sink);
 


### PR DESCRIPTION
Hello!

First off — thanks for creating DataTamer. It’s an awesome library.

I’ve been developing a ROS2 Jazzy system using a composition-based architecture with both lifecycle and regular nodes. We use DataTamer to collect time-series data and pipe it into Foxglove, and the ROS2 publisher sink makes that integration super smooth.

I ran into an issue when adding the ROS2 publisher sink inside composable nodes. In composition, node ownership changes — the executor owns the shared pointer and spins the nodes — so you often don’t have direct access to the node `shared_ptr` in the same way as when running standalone nodes. This affects both lifecycle and regular nodes.

I tried workarounds like `shared_from_this()`, but those are fragile and can easily lead to invalid weak pointers.

I noticed recent support for lifecycle nodes was added via additional constructor overloads, and this PR builds on that idea by updating `ROS2PublisherSink` to accept a `NodeInterfaces` façade instead of requiring a `shared_ptr`. Since this sink only needs the topics interface, this lets users pass either:

1. A `NodeInterfaces` object directly
2. A `Node` / `LifecycleNode`
3. A `shared_ptr` to either

while remaining fully backwards compatible.

I took my colleague @jlack1987’s advice (he’s been working with DataTamer for a while) and structured this to preserve all existing usage patterns.

Thanks again — happy to adjust anything if needed!

