### PR TITLE
Real-time friendly snapshot path: bounded allocation-free sink queue, tryTakeSnapshot(), startRecording()

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ visualize your logs offline or in real-time.
 - If you use `DataTamer::registerValue` you must be careful about the lifetime of the
 object. If you prefer a safer RAII interface, use `DataTamer::createLoggedValue` instead.
 
+## Real-time usage
+
+`takeSnapshot()` is designed to be called from a periodic loop, but a few
+details matter if that loop is a real-time control loop:
+
+- Call `channel->startRecording()` once, after registering all values and
+  adding all sinks, before the loop starts. Otherwise the first snapshot
+  registers the schema into every sink, which for `MCAPSink` means a write to
+  disk on the caller's thread.
+- Use `channel->tryTakeSnapshot()` instead of `takeSnapshot()`. If another
+  thread is calling `setEnabled()`, `unregister()`, `getSchema()` or holding
+  `writeMutex()`, the snapshot is skipped and `false` is returned instead of
+  blocking.
+- The handoff to the sinks is a bounded, lock-free queue of pre-allocated
+  snapshots (64 per sink by default, see `DataSinkBase::DataSinkBase(queue_size)`).
+  In steady state no heap allocation happens on the caller's thread. If a sink
+  cannot keep up, the newest snapshots are dropped and counted in
+  `DataSinkBase::droppedSnapshotsCount()`; memory never grows.
+- All sink work (MCAP writing, ROS 2 publishing) runs on one background thread
+  per sink, at default priority. Pin or reprioritize it as your platform requires.
+
 # Examples
 
 ## Basic example

--- a/data_tamer_cpp/include/data_tamer/channel.hpp
+++ b/data_tamer_cpp/include/data_tamer/channel.hpp
@@ -165,14 +165,44 @@ public:
   size_t getNumberOfSinks() const;
 
   /**
+   * @brief startRecording freezes the schema and registers it into all the
+   * sinks added so far. After this call, registering a new value throws.
+   *
+   * Calling it is optional: the first takeSnapshot() does the same thing.
+   * Call it explicitly, after registering all values and adding all sinks,
+   * when the first snapshot is taken from a real-time thread: sink setup can
+   * be slow (for instance MCAPSink writes the schema to disk).
+   */
+  void startRecording();
+
+  /**
    * @brief takeSnapshot copies the current value of all your registered values
    *  and send an instance of Snapshot to all your Sinks.
+   *
+   * This method blocks if another thread holds writeMutex() or is calling
+   * setEnabled(), unregister() or getSchema(). See tryTakeSnapshot().
    *
    * @param timestamp is the time since epoch, by default.
    *
    * @return true is succesfully pushed to all its sinks.
    */
   bool takeSnapshot(std::chrono::nanoseconds timestamp = NsecSinceEpoch());
+
+  /**
+   * @brief tryTakeSnapshot is the non-blocking version of takeSnapshot(),
+   * intended for real-time loops.
+   *
+   * If the channel mutex is held by another thread, the snapshot is skipped
+   * and the method returns false immediately. In steady state (after
+   * startRecording() and after the sinks have seen the largest payload) this
+   * method takes no blocking lock and performs no heap allocation.
+   *
+   * @param timestamp is the time since epoch, by default.
+   *
+   * @return true if the snapshot was taken and pushed to all its sinks.
+   *         false if it was skipped, or if at least one sink dropped it.
+   */
+  bool tryTakeSnapshot(std::chrono::nanoseconds timestamp = NsecSinceEpoch());
 
   /**
    * @brief getActiveFlags returns a serialized buffer, where
@@ -211,6 +241,11 @@ private:
   void updateTypeRegistryImpl(FieldsVector& fields, const char* name);
 
   void addCustomType(const std::string& custom_type_name, const FieldsVector& fields);
+
+  bool takeSnapshotImpl(std::chrono::nanoseconds timestamp, bool blocking);
+
+  // requires _p->mutex to be held by the caller
+  void startRecordingImpl();
 
   [[nodiscard]] RegistrationID registerValueImpl(const std::string& name,
                                                  ValuePtr&& value_ptr,

--- a/data_tamer_cpp/include/data_tamer/data_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/data_sink.hpp
@@ -55,7 +55,25 @@ using DataSnapshot = std::vector<uint8_t>;
 class DataSinkBase
 {
 public:
+  /// Default number of snapshots that can be queued before pushSnapshot()
+  /// starts dropping them.
+  static constexpr size_t kDefaultQueueSize = 64;
+
   DataSinkBase();
+
+  /**
+   * @brief Construct a sink with an explicit queue size.
+   *
+   * The sink pre-allocates `queue_size` Snapshot slots. pushSnapshot() copies
+   * into a free slot without allocating (once the slot's payload capacity has
+   * grown to the largest payload seen) and returns false, dropping the
+   * snapshot, if all slots are waiting to be consumed.
+   *
+   * @param queue_size             number of pre-allocated snapshots (minimum 1)
+   * @param reserved_payload_bytes optional initial capacity of each slot's payload,
+   *                               to avoid the one-off allocation on the first push.
+   */
+  explicit DataSinkBase(size_t queue_size, size_t reserved_payload_bytes = 0);
 
   DataSinkBase(const DataSinkBase& other) = delete;
   DataSinkBase& operator=(const DataSinkBase& other) = delete;
@@ -75,14 +93,25 @@ public:
   virtual void addChannel(const std::string& name, const Schema& schema) = 0;
 
   /**
-   * @brief pushSnapshot will push the data into a concurrent queue,
-   * that a different thread will consume, using storeSnapshot()
+   * @brief pushSnapshot will copy the data into a pre-allocated slot of a
+   * bounded lock-free queue, that a different thread will consume,
+   * using storeSnapshot().
+   *
+   * This method does not block and, in steady state, does not allocate.
+   * The one exception is the first call from a given thread, when the queue
+   * registers that thread as a producer.
    *
    * @param snapshot see type Snapshot for details
    *
-   * @return false if the queue is full and snapshot was not pushed
+   * @return false if the queue is full and snapshot was dropped
    */
   virtual bool pushSnapshot(const Snapshot& snapshot);
+
+  /// Number of snapshot slots in the queue.
+  size_t queueSize() const;
+
+  /// Number of snapshots dropped by pushSnapshot() because the queue was full.
+  size_t droppedSnapshotsCount() const;
 
 protected:
   /**

--- a/data_tamer_cpp/src/channel.cpp
+++ b/data_tamer_cpp/src/channel.cpp
@@ -2,8 +2,11 @@
 #include "data_tamer/data_sink.hpp"
 #include "data_tamer/contrib/SerializeMe.hpp"
 
+#include <algorithm>
+#include <atomic>
+#include <memory>
+#include <mutex>
 #include <unordered_map>
-#include <unordered_set>
 
 namespace DataTamer
 {
@@ -29,10 +32,15 @@ struct LogChannel::Pimpl
 
   Snapshot snapshot;
   Schema schema;
-  bool logging_started = false;
+  std::atomic<bool> logging_started = false;
 
-  mutable Mutex sinks_mutex;
-  std::unordered_set<std::shared_ptr<DataSinkBase>> sinks;
+  // The list of sinks is copy-on-write: add/remove build a new vector under
+  // sinks_mutex and swap it in atomically. takeSnapshot() only loads the
+  // pointer and never takes sinks_mutex, so it can not block behind a sink
+  // being added (which may do I/O in addChannel).
+  using SinkList = std::vector<std::shared_ptr<DataSinkBase>>;
+  mutable std::mutex sinks_mutex;
+  std::shared_ptr<const SinkList> sinks = std::make_shared<const SinkList>();
 };
 
 RegistrationID LogChannel::registerValueImpl(const std::string& name,
@@ -163,25 +171,37 @@ void LogChannel::addDataSink(std::shared_ptr<DataSinkBase> sink)
 {
   std::lock_guard const lock_sinks(_p->sinks_mutex);
 
-  // if we haven't already started logging, then takeSnapshot() handles adding the channel
+  auto current = std::atomic_load(&_p->sinks);
+  if(std::find(current->begin(), current->end(), sink) != current->end())
+  {
+    return;
+  }
+  // if we haven't already started logging, then startRecording() handles adding the channel
   // otherwise it must be done here so the sink knows about the existing schema
   if(_p->logging_started)
   {
     sink->addChannel(_p->channel_name, _p->schema);
   }
-  _p->sinks.insert(sink);
+  auto updated = std::make_shared<Pimpl::SinkList>(*current);
+  updated->push_back(std::move(sink));
+  std::atomic_store(&_p->sinks,
+                    std::shared_ptr<const Pimpl::SinkList>(std::move(updated)));
 }
 
 void LogChannel::removeDataSink(std::shared_ptr<DataSinkBase> sink)
 {
-  std::lock_guard const lock(_p->sinks_mutex);
-  _p->sinks.erase(sink);
+  std::lock_guard const lock_sinks(_p->sinks_mutex);
+
+  auto current = std::atomic_load(&_p->sinks);
+  auto updated = std::make_shared<Pimpl::SinkList>(*current);
+  updated->erase(std::remove(updated->begin(), updated->end(), sink), updated->end());
+  std::atomic_store(&_p->sinks,
+                    std::shared_ptr<const Pimpl::SinkList>(std::move(updated)));
 }
 
 size_t LogChannel::getNumberOfSinks() const
 {
-  std::lock_guard const lock(_p->sinks_mutex);
-  return _p->sinks.size();
+  return std::atomic_load(&_p->sinks)->size();
 }
 
 Schema LogChannel::getSchema() const
@@ -201,82 +221,116 @@ void LogChannel::addCustomType(const std::string& custom_type_name,
   _p->schema.custom_types[custom_type_name] = fields;
 }
 
+void LogChannel::startRecording()
+{
+  std::lock_guard const lock(_p->mutex);
+  startRecordingImpl();
+}
+
+void LogChannel::startRecordingImpl()
+{
+  // sinks_mutex is taken so that addDataSink() either sees logging_started == true
+  // (and calls addChannel itself) or is included in the loop below.
+  std::lock_guard const lock_sinks(_p->sinks_mutex);
+  if(_p->logging_started)
+  {
+    return;
+  }
+  _p->snapshot.schema_hash = _p->schema.hash;
+  auto sinks = std::atomic_load(&_p->sinks);
+  for(auto const& sink : *sinks)
+  {
+    sink->addChannel(_p->channel_name, _p->schema);
+  }
+  _p->logging_started = true;
+}
+
 bool LogChannel::takeSnapshot(std::chrono::nanoseconds timestamp)
 {
+  return takeSnapshotImpl(timestamp, true);
+}
+
+bool LogChannel::tryTakeSnapshot(std::chrono::nanoseconds timestamp)
+{
+  return takeSnapshotImpl(timestamp, false);
+}
+
+bool LogChannel::takeSnapshotImpl(std::chrono::nanoseconds timestamp, bool blocking)
+{
+  auto sinks = std::atomic_load(&_p->sinks);
+  if(sinks->empty())
   {
-    std::lock_guard const lock_sinks(_p->sinks_mutex);
-    if(_p->sinks.empty())
-    {
-      return false;
-    }
+    return false;
   }
 
+  std::unique_lock<Mutex> lock(_p->mutex, std::defer_lock);
+  if(blocking)
   {
-    std::lock_guard const lock(_p->mutex);
+    lock.lock();
+  }
+  else if(!lock.try_lock())
+  {
+    return false;
+  }
 
-    // update the _p->snapshot.active_mask if necessary
-    if(_p->mask_dirty)
-    {
-      _p->mask_dirty = false;
-      auto& mask = _p->snapshot.active_mask;
-      mask.clear();
-      const auto vect_size = (_p->series.size() + 7) / 8;  // ceiling size
-      mask.resize(vect_size, 0xFF);
-      for(size_t i = 0; i < _p->series.size(); i++)
-      {
-        auto const& instance = _p->series[i];
-        if(!instance.enabled)
-        {
-          SetBit(mask, i, false);
-        }
-      }
-    }
-
-    size_t payload_size = 0;
+  // update the _p->snapshot.active_mask if necessary
+  if(_p->mask_dirty)
+  {
+    _p->mask_dirty = false;
+    auto& mask = _p->snapshot.active_mask;
+    mask.clear();
+    const auto vect_size = (_p->series.size() + 7) / 8;  // ceiling size
+    mask.resize(vect_size, 0xFF);
     for(size_t i = 0; i < _p->series.size(); i++)
     {
       auto const& instance = _p->series[i];
-      payload_size += instance.holder.getSerializedSize();
-    }
-    _p->snapshot.payload.resize(payload_size);
-
-    // set up the channel if we haven't begun logging
-    if(!_p->logging_started)
-    {
-      _p->snapshot.schema_hash = _p->schema.hash;
-
-      std::lock_guard const lock_sinks(_p->sinks_mutex);
-      // start logging inside the sinks_mutex so that addDataSink does not have an incorrect value due to a race condition
-      _p->logging_started = true;
-      for(auto const& sink : _p->sinks)
+      if(!instance.enabled)
       {
-        sink->addChannel(_p->channel_name, _p->schema);
+        SetBit(mask, i, false);
       }
     }
-
-    _p->snapshot.timestamp = timestamp;
-    _p->snapshot.channel_name = channelName();
-
-    // serialize data into _p->snapshot.payload
-    SerializeMe::SpanBytes payload_buffer(_p->snapshot.payload);
-
-    for(auto const& entry : _p->series)
-    {
-      if(entry.enabled)
-      {
-        entry.holder.serialize(payload_buffer);
-      }
-    }
-    _p->snapshot.payload.resize(_p->snapshot.payload.size() - payload_buffer.size());
   }
 
-  bool all_pushed = true;
+  size_t payload_size = 0;
+  for(size_t i = 0; i < _p->series.size(); i++)
   {
-    std::lock_guard const lock_sinks(_p->sinks_mutex);
-    for(auto& sink : _p->sinks)
+    auto const& instance = _p->series[i];
+    payload_size += instance.holder.getSerializedSize();
+  }
+  _p->snapshot.payload.resize(payload_size);
+
+  // set up the sinks if we haven't begun logging.
+  // Note: this may block and do I/O. Call startRecording() beforehand to avoid
+  // paying this cost inside a real-time loop.
+  if(!_p->logging_started)
+  {
+    startRecordingImpl();
+    // the list may have changed while sinks_mutex was held
+    sinks = std::atomic_load(&_p->sinks);
+  }
+
+  _p->snapshot.timestamp = timestamp;
+  _p->snapshot.channel_name = channelName();
+
+  // serialize data into _p->snapshot.payload
+  SerializeMe::SpanBytes payload_buffer(_p->snapshot.payload);
+
+  for(auto const& entry : _p->series)
+  {
+    if(entry.enabled)
     {
-      all_pushed &= sink->pushSnapshot(_p->snapshot);
+      entry.holder.serialize(payload_buffer);
     }
+  }
+  _p->snapshot.payload.resize(_p->snapshot.payload.size() - payload_buffer.size());
+
+  // pushSnapshot() copies into a pre-allocated slot and never blocks, so it is
+  // cheap enough to keep _p->mutex held: this protects _p->snapshot from a
+  // concurrent takeSnapshot() on another thread.
+  bool all_pushed = true;
+  for(auto const& sink : *sinks)
+  {
+    all_pushed &= sink->pushSnapshot(_p->snapshot);
   }
   return all_pushed;
 }

--- a/data_tamer_cpp/src/data_sink.cpp
+++ b/data_tamer_cpp/src/data_sink.cpp
@@ -7,33 +7,72 @@
 namespace DataTamer
 {
 
+// Number of producer threads (i.e. threads calling takeSnapshot on channels
+// attached to this sink) for which the queue pre-allocates its blocks.
+// Beyond this number, the first push from a new thread may allocate.
+static constexpr size_t kExpectedProducerThreads = 4;
+
+// Initial capacity of each slot's active_mask: one bit per registered value,
+// so this covers channels with up to 512 values without any later growth.
+static constexpr size_t kReservedMaskBytes = 64;
+
 struct DataSinkBase::Pimpl
 {
-  Pimpl(DataSinkBase* self)
+  Pimpl(DataSinkBase* self, size_t queue_size, size_t reserved_payload_bytes)
+    : pool(queue_size)
+    , free_slots(queue_size, 0, kExpectedProducerThreads)
+    , ready_slots(queue_size, 0, kExpectedProducerThreads)
   {
-    run = true;
+    for(auto& slot : pool)
+    {
+      slot.payload.reserve(reserved_payload_bytes);
+      slot.active_mask.reserve(kReservedMaskBytes);
+      free_slots.enqueue(&slot);
+    }
 
+    run = true;
     thread = std::thread([this, self]() {
-      Snapshot snapshot_copy;
       while(run)
       {
-        while(queue.try_dequeue(snapshot_copy))
-        {
-          self->storeSnapshot(snapshot_copy);
-        }
+        drainQueue(self);
         // avoid busy loop
         std::this_thread::sleep_for(std::chrono::microseconds(250));
       }
     });
   }
 
+  void drainQueue(DataSinkBase* self)
+  {
+    Snapshot* slot = nullptr;
+    while(ready_slots.try_dequeue(slot))
+    {
+      self->storeSnapshot(*slot);
+      // capacity is sufficient by construction, but fall back to the
+      // allocating version rather than leaking a slot.
+      if(!free_slots.try_enqueue(slot))
+      {
+        free_slots.enqueue(slot);
+      }
+    }
+  }
+
   std::thread thread;
   std::atomic_bool run = true;
   std::atomic_bool accept_snapshots = true;
-  moodycamel::ConcurrentQueue<Snapshot> queue;
+  std::atomic<size_t> dropped_count = 0;
+
+  // Pre-allocated snapshots. Pointers to these slots travel through the
+  // two queues below; the slots themselves are never reallocated.
+  std::vector<Snapshot> pool;
+  moodycamel::ConcurrentQueue<Snapshot*> free_slots;
+  moodycamel::ConcurrentQueue<Snapshot*> ready_slots;
 };
 
-DataSinkBase::DataSinkBase() : _p(new Pimpl(this)) {}
+DataSinkBase::DataSinkBase() : DataSinkBase(kDefaultQueueSize, 0) {}
+
+DataSinkBase::DataSinkBase(size_t queue_size, size_t reserved_payload_bytes)
+  : _p(new Pimpl(this, queue_size == 0 ? 1 : queue_size, reserved_payload_bytes))
+{}
 
 DataSinkBase::~DataSinkBase()
 {
@@ -42,14 +81,46 @@ DataSinkBase::~DataSinkBase()
 
 bool DataSinkBase::pushSnapshot(const Snapshot& snapshot)
 {
-  if(_p->accept_snapshots)
-  {
-    return _p->queue.enqueue(snapshot);
-  }
-  else
+  if(!_p->accept_snapshots)
   {
     return false;
   }
+
+  Snapshot* slot = nullptr;
+  if(!_p->free_slots.try_dequeue(slot))
+  {
+    // queue is full: the consumer thread is not keeping up. Drop the newest.
+    _p->dropped_count.fetch_add(1, std::memory_order_relaxed);
+    return false;
+  }
+
+  // Copy into pre-allocated storage. std::vector::assign does not allocate
+  // when the new size fits the existing capacity, so after the slot has seen
+  // the largest payload once, this is a plain memcpy.
+  slot->channel_name = snapshot.channel_name;
+  slot->schema_hash = snapshot.schema_hash;
+  slot->timestamp = snapshot.timestamp;
+  slot->active_mask.assign(snapshot.active_mask.begin(), snapshot.active_mask.end());
+  slot->payload.assign(snapshot.payload.begin(), snapshot.payload.end());
+
+  if(!_p->ready_slots.try_enqueue(slot))
+  {
+    // Should not happen: both queues are sized for the whole pool.
+    _p->free_slots.enqueue(slot);
+    _p->dropped_count.fetch_add(1, std::memory_order_relaxed);
+    return false;
+  }
+  return true;
+}
+
+size_t DataSinkBase::queueSize() const
+{
+  return _p->pool.size();
+}
+
+size_t DataSinkBase::droppedSnapshotsCount() const
+{
+  return _p->dropped_count.load(std::memory_order_relaxed);
 }
 
 void DataSinkBase::stopAcceptingSnapshots()
@@ -64,11 +135,7 @@ void DataSinkBase::startAcceptingSnapshots()
 
 void DataSinkBase::processQueuedSnapshots()
 {
-  Snapshot snapshot_copy;
-  while(_p->queue.try_dequeue(snapshot_copy))
-  {
-    this->storeSnapshot(snapshot_copy);
-  }
+  _p->drainQueue(this);
 }
 
 void DataSinkBase::stopThread()

--- a/data_tamer_cpp/tests/CMakeLists.txt
+++ b/data_tamer_cpp/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ if(gtest_vendor_FOUND AND ament_cmake_gtest_FOUND)
         custom_types_tests.cpp
         parser_tests.cpp
         ros2_publisher_tests.cpp
+        realtime_tests.cpp
         trait_tests.cpp)
 
     target_include_directories(datatamer_test
@@ -30,7 +31,8 @@ else()
         dt_tests.cpp
         custom_types_tests.cpp
         parser_tests.cpp
-        add_remove_sink_tests.cpp)
+        add_remove_sink_tests.cpp
+        realtime_tests.cpp)
     gtest_discover_tests(datatamer_test DISCOVERY_MODE PRE_TEST)
 
     target_include_directories(datatamer_test

--- a/data_tamer_cpp/tests/realtime_tests.cpp
+++ b/data_tamer_cpp/tests/realtime_tests.cpp
@@ -1,0 +1,231 @@
+#include "data_tamer/channel.hpp"
+#include "data_tamer/sinks/dummy_sink.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <functional>
+#include <new>
+#include <thread>
+
+using namespace DataTamer;
+
+//------------------------------------------------------------------
+// Count heap allocations performed by the calling thread only.
+// Replacing the global operator new affects the whole test binary, but the
+// counter is only incremented while t_count_allocs is true on this thread.
+static std::atomic<long> g_alloc_count{ 0 };
+static thread_local bool t_count_allocs = false;
+
+void* operator new(std::size_t size)
+{
+  if(t_count_allocs)
+  {
+    g_alloc_count.fetch_add(1, std::memory_order_relaxed);
+  }
+  if(void* ptr = std::malloc(size == 0 ? 1 : size))
+  {
+    return ptr;
+  }
+  throw std::bad_alloc();
+}
+
+void operator delete(void* ptr) noexcept
+{
+  std::free(ptr);
+}
+
+void operator delete(void* ptr, std::size_t) noexcept
+{
+  std::free(ptr);
+}
+
+//------------------------------------------------------------------
+// A sink whose consumer thread can be held back, to fill the queue.
+class BlockingSink : public DataSinkBase
+{
+public:
+  explicit BlockingSink(size_t queue_size, size_t reserved_bytes = 0)
+    : DataSinkBase(queue_size, reserved_bytes)
+  {}
+
+  ~BlockingSink() override
+  {
+    release = true;
+    stopThread();
+  }
+
+  void addChannel(std::string const&, Schema const&) override {}
+
+  bool storeSnapshot(const Snapshot&) override
+  {
+    while(!release)
+    {
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+    stored_count++;
+    return true;
+  }
+
+  std::atomic<bool> release{ false };
+  std::atomic<int> stored_count{ 0 };
+};
+
+static void waitFor(std::function<bool()> predicate,
+                    std::chrono::milliseconds timeout = std::chrono::seconds(2))
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while(!predicate() && std::chrono::steady_clock::now() < deadline)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+//------------------------------------------------------------------
+
+TEST(RealTime, StartRecordingRegistersSchemaBeforeFirstSnapshot)
+{
+  auto channel = LogChannel::create("rt_start");
+  auto sink = std::make_shared<DummySink>();
+  channel->addDataSink(sink);
+
+  double value = 1.0;
+  channel->registerValue("value", &value);
+
+  {
+    std::scoped_lock lk(sink->schema_mutex_);
+    ASSERT_EQ(sink->schemas.count(channel->getSchema().hash), 0u);
+  }
+
+  channel->startRecording();
+
+  {
+    std::scoped_lock lk(sink->schema_mutex_);
+    ASSERT_EQ(sink->schemas.count(channel->getSchema().hash), 1u);
+    ASSERT_EQ(sink->snapshots_count[channel->getSchema().hash], 0);
+  }
+
+  // schema is frozen
+  int late = 0;
+  ASSERT_THROW(channel->registerValue("late", &late), std::runtime_error);
+
+  // a second call is a no-op
+  channel->startRecording();
+
+  // a sink added afterwards gets the schema immediately
+  auto late_sink = std::make_shared<DummySink>();
+  channel->addDataSink(late_sink);
+  {
+    std::scoped_lock lk(late_sink->schema_mutex_);
+    ASSERT_EQ(late_sink->schemas.count(channel->getSchema().hash), 1u);
+  }
+  ASSERT_EQ(channel->getNumberOfSinks(), 2u);
+}
+
+TEST(RealTime, TryTakeSnapshotDoesNotBlockOnWriteMutex)
+{
+  auto channel = LogChannel::create("rt_try");
+  auto sink = std::make_shared<DummySink>();
+  channel->addDataSink(sink);
+
+  double value = 1.0;
+  channel->registerValue("value", &value);
+  channel->startRecording();
+
+  {
+    std::unique_lock lk(channel->writeMutex());
+    // would deadlock if tryTakeSnapshot blocked
+    ASSERT_FALSE(channel->tryTakeSnapshot());
+  }
+  ASSERT_TRUE(channel->tryTakeSnapshot());
+
+  const auto hash = channel->getSchema().hash;
+  waitFor([&] {
+    std::scoped_lock lk(sink->schema_mutex_);
+    return sink->snapshots_count[hash] == 1;
+  });
+  std::scoped_lock lk(sink->schema_mutex_);
+  ASSERT_EQ(sink->snapshots_count[hash], 1);
+}
+
+TEST(RealTime, FullQueueDropsSnapshotsInsteadOfGrowing)
+{
+  constexpr size_t queue_size = 4;
+  auto channel = LogChannel::create("rt_queue");
+  auto sink = std::make_shared<BlockingSink>(queue_size);
+  channel->addDataSink(sink);
+
+  double value = 1.0;
+  channel->registerValue("value", &value);
+  channel->startRecording();
+
+  ASSERT_EQ(sink->queueSize(), queue_size);
+
+  int accepted = 0;
+  for(int i = 0; i < 10; i++)
+  {
+    accepted += channel->takeSnapshot() ? 1 : 0;
+  }
+  // the consumer is blocked inside storeSnapshot, so exactly queue_size
+  // snapshots could be stored in the pool. The others were dropped.
+  ASSERT_EQ(accepted, int(queue_size));
+  ASSERT_EQ(sink->droppedSnapshotsCount(), 10u - queue_size);
+
+  sink->release = true;
+  waitFor([&] { return sink->stored_count == int(queue_size); });
+  ASSERT_EQ(sink->stored_count, int(queue_size));
+
+  // once drained, pushing works again
+  ASSERT_TRUE(channel->takeSnapshot());
+  waitFor([&] { return sink->stored_count == int(queue_size) + 1; });
+  ASSERT_EQ(sink->stored_count, int(queue_size) + 1);
+}
+
+TEST(RealTime, SteadyStateSnapshotDoesNotAllocate)
+{
+  constexpr size_t queue_size = 8;
+  auto channel = LogChannel::create("rt_alloc");
+  // reserve enough bytes for the payload below, so that no slot has to grow
+  auto sink = std::make_shared<BlockingSink>(queue_size, 4096);
+  sink->release = true;
+  channel->addDataSink(sink);
+
+  std::vector<double> vect(100, 1.0);
+  std::array<float, 16> arr{};
+  double scalar = 0;
+  int32_t counter = 0;
+  channel->registerValue("vect", &vect);
+  channel->registerValue("arr", &arr);
+  channel->registerValue("scalar", &scalar);
+  channel->registerValue("counter", &counter);
+  channel->startRecording();
+
+  // warm up: registers this thread as a producer in the queue and lets every
+  // slot see the payload once.
+  for(size_t i = 0; i < queue_size * 4; i++)
+  {
+    channel->takeSnapshot();
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
+  }
+  waitFor([&] { return sink->stored_count == int(queue_size * 4); });
+
+  g_alloc_count = 0;
+  t_count_allocs = true;
+  int taken = 0;
+  for(int i = 0; i < 1000; i++)
+  {
+    scalar += 1.0;
+    counter++;
+    taken += channel->tryTakeSnapshot() ? 1 : 0;
+    if((i % 4) == 3)
+    {
+      // leave room for the consumer, so that most snapshots are accepted
+      std::this_thread::sleep_for(std::chrono::microseconds(300));
+    }
+  }
+  t_count_allocs = false;
+
+  ASSERT_GT(taken, 0);
+  ASSERT_EQ(g_alloc_count.load(), 0) << "takeSnapshot allocated on the caller thread";
+}


### PR DESCRIPTION
Addresses the real-time items of #73 (blocking locks, per-tick heap allocations, sink setup on the first tick, unbounded queue). The `std::array` compile error and the schema hash gap from that issue are left for separate PRs.

## What changes

**`DataSinkBase`: bounded, allocation-free handoff** (`src/data_sink.cpp`)
- The `ConcurrentQueue<Snapshot>` is replaced by a pool of `queue_size` pre-allocated `Snapshot` slots and two `ConcurrentQueue<Snapshot*>` (free list and ready list) that never allocate on `try_enqueue`/`try_dequeue`.
- `pushSnapshot()` takes a free slot, copies with `vector::assign` (no allocation once the slot's capacity covers the payload) and pushes the pointer. If no slot is free the snapshot is dropped and counted; memory never grows.
- New constructor `DataSinkBase(size_t queue_size, size_t reserved_payload_bytes = 0)`; default constructor keeps `kDefaultQueueSize = 64`. New getters `queueSize()` and `droppedSnapshotsCount()`.

**`LogChannel::tryTakeSnapshot()`** (`src/channel.cpp`)
- Same as `takeSnapshot()` but `try_lock`s the channel mutex and returns `false` if another thread holds it. Dropping a sample is the failure mode a control loop wants.
- The sink list is now copy-on-write (`shared_ptr<const vector>` swapped with `std::atomic_store`). Neither snapshot variant takes `sinks_mutex` anymore, so a concurrent `addDataSink()` doing I/O in `addChannel()` cannot stall the producer. `addDataSink()` also dedupes, matching the previous `unordered_set` semantics.
- The push loop now runs while the channel mutex is still held, which protects `_p->snapshot` against two threads snapshotting the same channel (previously a race).

**`LogChannel::startRecording()`**
- Freezes the schema and calls `addChannel()` on all sinks. Optional: the first snapshot still does this lazily, but a real-time caller can now do it at setup time. Idempotent; sinks added afterwards get the schema immediately, as before.

**README**: new "Real-time usage" section.

## Behaviour changes to be aware of
- A sink that cannot keep up now drops the newest snapshots after 64 queued (configurable) instead of growing the queue without bound. `pushSnapshot()` already documented `false` as "queue full", so the contract is unchanged, but the outcome is now reachable.
- The first `pushSnapshot()` from a new thread lets the queue register that thread as a producer, which may allocate once. Pre-allocation covers up to 4 producer threads per sink.

## Tests
`tests/realtime_tests.cpp`, four cases:
- `startRecording()` registers the schema before any snapshot, freezes registration, is idempotent, and late sinks still get the schema.
- `tryTakeSnapshot()` returns `false` while `writeMutex()` is held by the test, `true` afterwards.
- With a consumer blocked inside `storeSnapshot()` and `queue_size = 4`, 10 pushes yield exactly 4 accepted and `droppedSnapshotsCount() == 6`; after release, pushing works again.
- Steady-state `tryTakeSnapshot()` on a channel with a 100-double vector, a `std::array<float,16>` and two scalars performs **zero** heap allocations on the calling thread, measured by a replaced global `operator new` gated by a `thread_local` flag.

Full suite (28 tests) passes in Debug and Release (`-Wall -Wextra`, no new warnings). The `RealTime.*` tests pass 50 consecutive repeats. Not run here: the ROS 2 build (`ros2_publisher_sink` is untouched and only uses the `DataSinkBase` interface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
