### PR TITLE
Declare lz4 and zstd dependencies in package.xml

### DIFF
--- a/data_tamer_cpp/package.xml
+++ b/data_tamer_cpp/package.xml
@@ -20,6 +20,8 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>mcap_vendor</depend>
+  <depend>lz4</depend>
+  <depend>libzstd-dev</depend>
   <depend>data_tamer_msgs</depend>
   <depend>ament_cmake_gtest</depend>
   <depend>gtest_vendor</depend>


### PR DESCRIPTION
Addresses the dependency part of #41: `mcap_sink.cpp` compiles the MCAP writer with `MCAP_IMPLEMENTATION`, which includes `lz4.h`/`lz4frame.h` and `zstd.h` directly, yet `package.xml` declared neither. Adds `<depend>lz4</depend>` and `<depend>libzstd-dev</depend>` (both resolve with rosdep on Ubuntu).

The other point in #41, renaming the exported CMake namespace from `data_tamer::` to `data_tamer_cpp::`, is intentionally not done: it would break every downstream `target_link_libraries(... data_tamer::data_tamer)`. If we want the project-name namespace, the way to do it is an alias target alongside the existing one, in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)