### PR TITLE
Fix SerializeMe byte-array copy direction and misaligned loads

### DIFF
--- a/data_tamer_cpp/include/data_tamer/contrib/SerializeMe.hpp
+++ b/data_tamer_cpp/include/data_tamer/contrib/SerializeMe.hpp
@@ -391,7 +391,7 @@ inline void DeserializeFromBuffer(SpanBytesConst& buffer, T& dest)
     {
       throw std::runtime_error("DeserializeFromBuffer: buffer overflow");
     }
-    dest = *(reinterpret_cast<T const*>(buffer.data()));
+    std::memcpy(&dest, buffer.data(), S);  // buffer.data() may be misaligned for T
 
 #if SERIALIZE_LITTLEENDIAN == 0
     dest = EndianSwap<T>(dest);
@@ -555,7 +555,7 @@ inline void SerializeIntoBuffer(SpanBytes& buffer, std::array<T, N> const& vect)
 
   if constexpr(sizeof(T) == 1)
   {
-    std::memcpy(vect.data(), buffer.data(), N);
+    std::memcpy(buffer.data(), vect.data(), N);
     buffer.trimFront(N);
   }
   else

--- a/data_tamer_cpp/tests/CMakeLists.txt
+++ b/data_tamer_cpp/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ if(gtest_vendor_FOUND AND ament_cmake_gtest_FOUND)
         custom_types_tests.cpp
         parser_tests.cpp
         ros2_publisher_tests.cpp
+        serialize_me_tests.cpp
         trait_tests.cpp)
 
     target_include_directories(datatamer_test
@@ -30,6 +31,7 @@ else()
         dt_tests.cpp
         custom_types_tests.cpp
         parser_tests.cpp
+        serialize_me_tests.cpp
         add_remove_sink_tests.cpp)
     gtest_discover_tests(datatamer_test DISCOVERY_MODE PRE_TEST)
 

--- a/data_tamer_cpp/tests/serialize_me_tests.cpp
+++ b/data_tamer_cpp/tests/serialize_me_tests.cpp
@@ -34,7 +34,8 @@ TEST(SerializeMe, NumbersRoundTripAtUnalignedOffsets)
   const double d = 3.25;
   const int32_t i = -42;
   const uint64_t u = 0x0102030405060708ULL;
-  std::vector<uint8_t> storage(BufferSize(tag) + BufferSize(d) + BufferSize(i) + BufferSize(u));
+  std::vector<uint8_t> storage(BufferSize(tag) + BufferSize(d) + BufferSize(i) +
+                               BufferSize(u));
   SpanBytes buffer(storage);
   SerializeIntoBuffer(buffer, tag);
   SerializeIntoBuffer(buffer, d);

--- a/data_tamer_cpp/tests/serialize_me_tests.cpp
+++ b/data_tamer_cpp/tests/serialize_me_tests.cpp
@@ -1,0 +1,59 @@
+#include "data_tamer/contrib/SerializeMe.hpp"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+using namespace SerializeMe;
+
+// Issue #73: the sizeof(T) == 1 branch copied in the wrong direction and did not
+// even compile (const source used as destination).
+TEST(SerializeMe, ByteArrayIsSerializedIntoTheBuffer)
+{
+  const std::array<uint8_t, 4> values = { 1, 2, 3, 4 };
+  std::vector<uint8_t> storage(BufferSize(values), 0xEE);
+  SpanBytes buffer(storage);
+  SerializeIntoBuffer(buffer, values);
+  ASSERT_EQ(buffer.size(), 0u);
+  ASSERT_EQ(storage, (std::vector<uint8_t>{ 1, 2, 3, 4 }));
+
+  std::array<uint8_t, 4> decoded{};
+  SpanBytesConst input(storage.data(), storage.size());
+  DeserializeFromBuffer(input, decoded);
+  ASSERT_EQ(decoded, values);
+}
+
+// Issue #42: numbers were read through a reinterpret_cast, which is undefined
+// behaviour at unaligned offsets. A leading byte forces every following field
+// off its natural alignment; UBSAN fails this test with the old code.
+TEST(SerializeMe, NumbersRoundTripAtUnalignedOffsets)
+{
+  const uint8_t tag = 7;
+  const double d = 3.25;
+  const int32_t i = -42;
+  const uint64_t u = 0x0102030405060708ULL;
+  std::vector<uint8_t> storage(BufferSize(tag) + BufferSize(d) + BufferSize(i) + BufferSize(u));
+  SpanBytes buffer(storage);
+  SerializeIntoBuffer(buffer, tag);
+  SerializeIntoBuffer(buffer, d);
+  SerializeIntoBuffer(buffer, i);
+  SerializeIntoBuffer(buffer, u);
+  ASSERT_EQ(buffer.size(), 0u);
+
+  SpanBytesConst input(storage.data(), storage.size());
+  uint8_t tag_out = 0;
+  double d_out = 0;
+  int32_t i_out = 0;
+  uint64_t u_out = 0;
+  DeserializeFromBuffer(input, tag_out);
+  DeserializeFromBuffer(input, d_out);
+  DeserializeFromBuffer(input, i_out);
+  DeserializeFromBuffer(input, u_out);
+  ASSERT_EQ(tag_out, tag);
+  ASSERT_EQ(d_out, d);
+  ASSERT_EQ(i_out, i);
+  ASSERT_EQ(u_out, u);
+  ASSERT_EQ(input.size(), 0u);
+}


### PR DESCRIPTION
Two bugs in `contrib/SerializeMe.hpp`, both with unit tests in a new `tests/serialize_me_tests.cpp`.

- **#73, item 1.** `SerializeIntoBuffer(SpanBytes&, std::array<T,N> const&)` in the `sizeof(T) == 1` branch had the `memcpy` arguments swapped, copying the buffer into the `const` array. It did not compile when instantiated, so registering a `std::array<uint8_t, N>` was impossible. Fixed and covered by a round-trip test.
- **#42.** `DeserializeFromBuffer` read numbers with `dest = *reinterpret_cast<T const*>(buffer.data())`, which is undefined behaviour whenever the byte offset is not a multiple of `alignof(T)`. Replaced by `memcpy`. The new test places a `double`, an `int32_t` and a `uint64_t` after one leading byte; with the old code UBSAN reports `load of misaligned address ... for type 'const double'`, with the fix the full suite passes under `-fsanitize=undefined`.

No wire-format change: the bytes written and read are identical, only how they are accessed.

Closes #42. The remaining items of #73 (schema hash coverage, dead slots after `unregister`) are unaffected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)