### PR TITLE
CI: keep the rolling ROS job from cancelling the other distros

### DIFF
--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   industrial_ci:
     strategy:
+      fail-fast: false  # one distro's infrastructure failure must not cancel the others
       matrix:
         env:
           - {ROS_DISTRO: humble, ROS_REPO: main}
@@ -12,7 +13,9 @@ jobs:
           - {ROS_DISTRO: jazzy, ROS_REPO: main}
           - {ROS_DISTRO: rolling, ROS_REPO: main}
     runs-on: ubuntu-latest
+    # rolling tracks a Ubuntu release that packages.ros.org does not serve yet
+    continue-on-error: ${{ matrix.env.ROS_DISTRO == 'rolling' }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: 'ros-industrial/industrial_ci@master'
         env: ${{matrix.env}}


### PR DESCRIPTION
The `rolling` industrial_ci job fails to install `ros-rolling-ros-environment` because its container has moved to a Ubuntu release that packages.ros.org does not serve yet. With the default `fail-fast`, that failure cancels the humble, iron and jazzy jobs before they run, which is why the `ros2` workflow has shown red on `main` since July.

- `fail-fast: false` so each distro reports its own result.
- `continue-on-error` for rolling only, so it stays visible but advisory until the packages exist.
- `actions/checkout` v1 to v4.

Same change as in #75, extracted so `main` and the small PRs (#76, #77, #78) can go green independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)