### PR TITLE
Schema version 5: platform-independent hash that covers custom types

### DIFF
--- a/data_tamer_cpp/CHANGELOG.rst
+++ b/data_tamer_cpp/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog for package data_tamer
 
 Unreleased
 ----------
+* Schema version 5: the schema hash is FNV-1a 64 of the schema text (minus its
+  own hash line), so it is identical on every platform, verifiable by any
+  decoder and covers custom type bodies. Readers accept version 4 files through
+  their declared hash; parsers older than this release reject version 5 files
+  with "Wrong SCHEMA_VERSION". ``AddFieldToHash`` is replaced by
+  ``SchemaTextHash``/``ComputeSchemaHash``.
 * Real-time front end, steps 0–8: scalar ``LoggedValue`` values use lock-free
   atomics; ``set()``/``get()`` are wait-free. Non-scalar updates and snapshot
   serialization share a priority-inheriting mutex. ``LogChannel::scopedWrite()``

--- a/data_tamer_cpp/CHANGELOG.rst
+++ b/data_tamer_cpp/CHANGELOG.rst
@@ -8,8 +8,9 @@ Unreleased
   own hash line), so it is identical on every platform, verifiable by any
   decoder and covers custom type bodies. Readers accept version 4 files through
   their declared hash; parsers older than this release reject version 5 files
-  with "Wrong SCHEMA_VERSION". ``AddFieldToHash`` is replaced by
-  ``SchemaTextHash``/``ComputeSchemaHash``.
+  with "Wrong SCHEMA_VERSION". In the library ``AddFieldToHash`` is replaced by
+  ``SchemaTextHash``/``ComputeSchemaHash``; the header-only parser keeps it
+  for version 4 texts.
 * Real-time front end, steps 0–8: scalar ``LoggedValue`` values use lock-free
   atomics; ``set()``/``get()`` are wait-free. Non-scalar updates and snapshot
   serialization share a priority-inheriting mutex. ``LogChannel::scopedWrite()``

--- a/data_tamer_cpp/include/data_tamer/types.hpp
+++ b/data_tamer_cpp/include/data_tamer/types.hpp
@@ -5,6 +5,7 @@
 
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <map>
 #include <unordered_map>
 #include <vector>
@@ -13,7 +14,7 @@
 namespace DataTamer
 {
 
-constexpr int SCHEMA_VERSION = 4;
+constexpr int SCHEMA_VERSION = 5;
 
 // clang-format off
 enum class BasicType: uint8_t
@@ -147,7 +148,16 @@ struct Schema
 
 std::string ToStr(const Schema& schema);
 
-[[nodiscard]] uint64_t AddFieldToHash(const TypeField& field, uint64_t hash);
+/**
+ * @brief Hash of a schema text (see docs/wire_format.md, section 5): FNV-1a 64 over
+ * the text with its "### hash:" line removed. Defined byte for byte, so any decoder
+ * can recompute it and two schemas that differ anywhere, including inside a custom
+ * type, get different hashes.
+ */
+[[nodiscard]] uint64_t SchemaTextHash(std::string_view schema_text);
+
+/// SchemaTextHash() of ToStr(schema); the value Schema::hash must hold.
+[[nodiscard]] uint64_t ComputeSchemaHash(const Schema& schema);
 
 }  // namespace DataTamer
 

--- a/data_tamer_cpp/include/data_tamer_parser/data_tamer_parser.hpp
+++ b/data_tamer_cpp/include/data_tamer_parser/data_tamer_parser.hpp
@@ -184,7 +184,34 @@ inline bool GetBit(BufferSpan mask, size_t index)
   return 0 != (byte & uint8_t(1 << (index % 8)));
 }
 
-/// FNV-1a 64 of the schema text without its "### hash:" line (wire format, section 5).
+/// Hash recipe of schema version 4 (std::hash based, so only reproducible on the
+/// writer's platform). Kept so that version 4 texts are read and verified exactly
+/// as before.
+[[nodiscard]] inline uint64_t AddFieldToHash(const TypeField& field, uint64_t hash)
+{
+  // https://stackoverflow.com/questions/2590677/how-do-i-combine-hash-values-in-c0x
+  const std::hash<std::string> str_hasher;
+  const std::hash<uint8_t> type_hasher;
+  const std::hash<bool> bool_hasher;
+  const std::hash<uint32_t> uint_hasher;
+
+  auto combine = [&hash](const auto& hasher, const auto& val) {
+    hash ^= hasher(val) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+  };
+
+  combine(str_hasher, field.field_name);
+  combine(type_hasher, static_cast<uint8_t>(field.type));
+  if(field.type == BasicType::OTHER)
+  {
+    combine(str_hasher, field.type_name);
+  }
+  combine(bool_hasher, field.is_vector);
+  combine(uint_hasher, field.array_size);
+  return hash;
+}
+
+/// Hash recipe of schema version 5: FNV-1a 64 of the schema text without its
+/// "### hash:" line (wire format, section 5). Platform independent.
 [[nodiscard]] inline uint64_t SchemaTextHash(const std::string& text)
 {
   uint64_t hash = 0xcbf29ce484222325ULL;
@@ -234,6 +261,8 @@ inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false
   std::string line;
   Schema schema;
   uint64_t declared_schema = 0;
+  int version = SCHEMA_VERSION;
+  uint64_t legacy_hash = 0;  // version 4 recomputation, field by field
 
   std::vector<TypeField>* field_vector = &schema.fields;
 
@@ -280,9 +309,8 @@ inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false
 
     if(str_left == "### version:")
     {
-      // Version 4 differs only in how the hash was computed; its declared value
-      // is still the one to match snapshots against.
-      const int version = std::stoi(str_right);
+      // Version 4 differs only in how the hash was computed.
+      version = std::stoi(str_right);
       if(version != SCHEMA_VERSION && version != 4)
       {
         throw std::runtime_error("Wrong SCHEMA_VERSION");
@@ -300,6 +328,7 @@ inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false
     {
       // check compatibility
       schema.channel_name = str_right;
+      legacy_hash = std::hash<std::string>()(schema.channel_name);
       continue;
     }
 
@@ -355,12 +384,16 @@ inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false
     field.field_name = *str_name;
     trimString(field.field_name);
 
+    if(version == 4 && field_vector == &schema.fields)
+    {
+      legacy_hash = AddFieldToHash(field, legacy_hash);
+    }
     field_vector->push_back(field);
   }
   // Snapshots carry the writer's declared hash: that is what to match against.
-  // check_hash verifies it against the defined recomputation (version 5 texts only;
-  // version 4 used an implementation-defined std::hash and cannot be verified).
-  const uint64_t computed = SchemaTextHash(txt);
+  // check_hash verifies it against the recomputation of the text's own version
+  // (version 4's std::hash recipe only agrees on the writer's platform).
+  const uint64_t computed = version == 4 ? legacy_hash : SchemaTextHash(txt);
   if(check_hash && declared_schema != 0 && declared_schema != computed)
   {
     throw std::runtime_error("Error in hash calculation");

--- a/data_tamer_cpp/include/data_tamer_parser/data_tamer_parser.hpp
+++ b/data_tamer_cpp/include/data_tamer_parser/data_tamer_parser.hpp
@@ -17,7 +17,7 @@
 namespace DataTamerParser
 {
 
-constexpr int SCHEMA_VERSION = 4;
+constexpr int SCHEMA_VERSION = 5;
 
 enum class BasicType : uint8_t
 {
@@ -184,26 +184,29 @@ inline bool GetBit(BufferSpan mask, size_t index)
   return 0 != (byte & uint8_t(1 << (index % 8)));
 }
 
-[[nodiscard]] inline uint64_t AddFieldToHash(const TypeField& field, uint64_t hash)
+/// FNV-1a 64 of the schema text without its "### hash:" line (wire format, section 5).
+[[nodiscard]] inline uint64_t SchemaTextHash(const std::string& text)
 {
-  // https://stackoverflow.com/questions/2590677/how-do-i-combine-hash-values-in-c0x
-  const std::hash<std::string> str_hasher;
-  const std::hash<uint8_t> type_hasher;
-  const std::hash<bool> bool_hasher;
-  const std::hash<uint32_t> uint_hasher;
-
-  auto combine = [&hash](const auto& hasher, const auto& val) {
-    hash ^= hasher(val) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+  uint64_t hash = 0xcbf29ce484222325ULL;
+  auto feed = [&hash](const char* begin, const char* end) {
+    for(; begin != end; ++begin)
+    {
+      hash ^= static_cast<uint8_t>(*begin);
+      hash *= 0x100000001b3ULL;
+    }
   };
-
-  combine(str_hasher, field.field_name);
-  combine(type_hasher, static_cast<uint8_t>(field.type));
-  if(field.type == BasicType::OTHER)
+  const auto hash_line = text.find("### hash:");
+  if(hash_line == std::string::npos)
   {
-    combine(str_hasher, field.type_name);
+    feed(text.data(), text.data() + text.size());
+    return hash;
   }
-  combine(bool_hasher, field.is_vector);
-  combine(uint_hasher, field.array_size);
+  const auto line_end = text.find('\n', hash_line);
+  feed(text.data(), text.data() + hash_line);
+  if(line_end != std::string::npos)
+  {
+    feed(text.data() + line_end + 1, text.data() + text.size());
+  }
   return hash;
 }
 
@@ -277,8 +280,10 @@ inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false
 
     if(str_left == "### version:")
     {
-      // check compatibility
-      if(std::stoi(str_right) != SCHEMA_VERSION)
+      // Version 4 differs only in how the hash was computed; its declared value
+      // is still the one to match snapshots against.
+      const int version = std::stoi(str_right);
+      if(version != SCHEMA_VERSION && version != 4)
       {
         throw std::runtime_error("Wrong SCHEMA_VERSION");
       }
@@ -295,7 +300,6 @@ inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false
     {
       // check compatibility
       schema.channel_name = str_right;
-      schema.hash = std::hash<std::string>()(schema.channel_name);
       continue;
     }
 
@@ -351,24 +355,17 @@ inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false
     field.field_name = *str_name;
     trimString(field.field_name);
 
-    // update the hash
-    if(field_vector == &schema.fields)
-    {
-      schema.hash = AddFieldToHash(field, schema.hash);
-    }
-
     field_vector->push_back(field);
   }
-  if(check_hash && declared_schema != 0 && declared_schema != schema.hash)
+  // Snapshots carry the writer's declared hash: that is what to match against.
+  // check_hash verifies it against the defined recomputation (version 5 texts only;
+  // version 4 used an implementation-defined std::hash and cannot be verified).
+  const uint64_t computed = SchemaTextHash(txt);
+  if(check_hash && declared_schema != 0 && declared_schema != computed)
   {
     throw std::runtime_error("Error in hash calculation");
   }
-  // The writer's hash is std::hash based, so it is only reproducible with the same
-  // standard library. Snapshots carry the writer's value: match against that.
-  if(declared_schema != 0)
-  {
-    schema.hash = declared_schema;
-  }
+  schema.hash = declared_schema != 0 ? declared_schema : computed;
   return schema;
 }
 

--- a/data_tamer_cpp/src/channel.cpp
+++ b/data_tamer_cpp/src/channel.cpp
@@ -145,7 +145,7 @@ RegistrationID LogChannel::registerValueImpl(const std::string& name,
     _p->shared->addSeries();
     const size_t index = _p->series.size() - 1;
     _p->registered_values.insert({ name, index });
-    _p->schema.hash = AddFieldToHash(field, _p->schema.hash);
+
     _p->schema.fields.emplace_back(std::move(field));
     if(type_info)
     {
@@ -153,6 +153,8 @@ RegistrationID LogChannel::registerValueImpl(const std::string& name,
       if(custom_schema && _p->schema.custom_types.count(type_info->typeName()) == 0)
         _p->schema.custom_schemas.insert({ type_info->typeName(), *custom_schema });
     }
+
+    _p->schema.hash = ComputeSchemaHash(_p->schema);
     return { index, 1 };
   }
 
@@ -170,9 +172,9 @@ RegistrationID LogChannel::registerValueImpl(const std::string& name,
 
 LogChannel::LogChannel(std::string name) : _p(new Pimpl)
 {
-  _p->schema.hash = std::hash<std::string>()(name);
   _p->schema.channel_name = name;
   _p->channel_name = std::move(name);
+  _p->schema.hash = ComputeSchemaHash(_p->schema);
 }
 
 std::shared_ptr<LogChannel> LogChannel::create(std::string name)
@@ -356,6 +358,7 @@ void LogChannel::addCustomType(const std::string& custom_type_name,
                                const FieldsVector& fields)
 {
   _p->schema.custom_types[custom_type_name] = fields;
+  _p->schema.hash = ComputeSchemaHash(_p->schema);
 }
 
 std::mutex& LogChannel::controlMutex()

--- a/data_tamer_cpp/src/types.cpp
+++ b/data_tamer_cpp/src/types.cpp
@@ -93,27 +93,34 @@ VarNumber DeserializeAsVarType(const BasicType& type, const void* data)
   return {};
 }
 
-uint64_t AddFieldToHash(const TypeField& field, uint64_t hash)
+uint64_t SchemaTextHash(std::string_view text)
 {
-  // https://stackoverflow.com/questions/2590677/how-do-i-combine-hash-values-in-c0x
-  const std::hash<std::string> str_hasher;
-  const std::hash<uint8_t> type_hasher;
-  const std::hash<bool> bool_hasher;
-  const std::hash<uint32_t> uint_hasher;
-
-  auto combine = [&hash](const auto& hasher, const auto& val) {
-    hash ^= hasher(val) + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+  uint64_t hash = 0xcbf29ce484222325ULL;  // FNV-1a 64, see docs/wire_format.md
+  auto feed = [&hash](std::string_view bytes) {
+    for(const char c : bytes)
+    {
+      hash ^= static_cast<uint8_t>(c);
+      hash *= 0x100000001b3ULL;
+    }
   };
-
-  combine(str_hasher, field.field_name);
-  combine(type_hasher, static_cast<uint8_t>(field.type));
-  if(field.type == BasicType::OTHER)
+  const auto hash_line = text.find("### hash:");
+  if(hash_line == std::string_view::npos)
   {
-    combine(str_hasher, field.type_name);
+    feed(text);
+    return hash;
   }
-  combine(bool_hasher, field.is_vector);
-  combine(uint_hasher, field.array_size);
+  const auto line_end = text.find('\n', hash_line);
+  feed(text.substr(0, hash_line));
+  if(line_end != std::string_view::npos)
+  {
+    feed(text.substr(line_end + 1));
+  }
   return hash;
+}
+
+uint64_t ComputeSchemaHash(const Schema& schema)
+{
+  return SchemaTextHash(ToStr(schema));
 }
 
 std::ostream& operator<<(std::ostream& os, const TypeField& field)

--- a/data_tamer_cpp/tests/parser_tests.cpp
+++ b/data_tamer_cpp/tests/parser_tests.cpp
@@ -294,3 +294,41 @@ TEST(DataTamerParser, VectorParsing)
   ASSERT_EQ(parsed_values.at("quats[1]/y"), 32);
   ASSERT_EQ(parsed_values.at("quats[1]/z"), 33);
 }
+
+// Version 4 texts (std::hash recipe) must still parse and verify exactly as before;
+// version 5 texts verify with the platform-independent recipe.
+TEST(DataTamerParser, ReadsAndVerifiesBothSchemaVersions)
+{
+  auto channel = DataTamer::LogChannel::create("chan");
+  Pose pose;
+  int32_t count = 0;
+  channel->registerValue("pose", &pose);
+  channel->registerValue("count", &count);
+  const std::string v5_text = ToStr(channel->getSchema());
+
+  // version 5: declared hash equals the defined recomputation
+  const auto v5 = BuilSchemaFromText(v5_text, /*check_hash=*/true);
+  ASSERT_EQ(v5.hash, SchemaTextHash(v5_text));
+  ASSERT_EQ(v5.hash, channel->getSchema().hash);
+  auto broken = v5_text;
+  broken.replace(broken.find("### hash: ") + 10, 1, "9");
+  EXPECT_THROW(BuilSchemaFromText(broken, true), std::runtime_error);
+
+  // version 4: the same fields, hashed with the legacy recipe
+  uint64_t legacy = std::hash<std::string>()(v5.channel_name);
+  for(const auto& field : v5.fields)
+  {
+    legacy = AddFieldToHash(field, legacy);
+  }
+  std::string v4_text = v5_text;
+  v4_text.replace(v4_text.find("### version: 5"), 14, "### version: 4");
+  const auto hash_pos = v4_text.find("### hash: ") + 10;
+  v4_text.replace(hash_pos, v4_text.find('\n', hash_pos) - hash_pos,
+                  std::to_string(legacy));
+  const auto v4 = BuilSchemaFromText(v4_text, /*check_hash=*/true);
+  ASSERT_EQ(v4.hash, legacy);
+  ASSERT_EQ(v4.fields.size(), v5.fields.size());
+  ASSERT_EQ(v4.custom_types.size(), v5.custom_types.size());
+
+  EXPECT_THROW(BuilSchemaFromText("### version: 3\n"), std::runtime_error);
+}

--- a/data_tamer_cpp/tests/wire_format_tests.cpp
+++ b/data_tamer_cpp/tests/wire_format_tests.cpp
@@ -76,14 +76,6 @@ void checkGolden(const std::string& name, const std::vector<uint8_t>& actual)
                               << " (see docs/wire_format.md)";
 }
 
-// The hash is std::hash based and therefore implementation-defined (spec section 5):
-// the fixture keeps the value of the machine that generated it, comparisons ignore it.
-std::string withoutHash(std::string text)
-{
-  const auto start = text.find("### hash: ") + 10;
-  text.replace(start, text.find('\n', start) - start, "0");
-  return text;
-}
 }  // namespace
 
 TEST(WireFormat, SchemaTextAndSnapshotsMatchGoldenVectors)
@@ -142,16 +134,8 @@ TEST(WireFormat, SchemaTextAndSnapshotsMatchGoldenVectors)
   const Snapshot full = sink->latestSnapshot();
 
   const std::string schema_text = ToStr(channel->getSchema());
-  if(std::getenv("DATA_TAMER_UPDATE_GOLDEN"))
-  {
-    checkGolden("schema.txt", { schema_text.begin(), schema_text.end() });
-  }
-  else
-  {
-    const auto golden = readFile("schema.txt");
-    ASSERT_FALSE(golden.empty()) << "missing fixture schema.txt";
-    EXPECT_EQ(withoutHash(schema_text), withoutHash({ golden.begin(), golden.end() }));
-  }
+  checkGolden("schema.txt", { schema_text.begin(), schema_text.end() });
+  EXPECT_EQ(channel->getSchema().hash, SchemaTextHash(schema_text));
   checkGolden("snapshot_full.mask", full.active_mask);
   checkGolden("snapshot_full.payload", full.payload);
 

--- a/docs/wire_format.md
+++ b/docs/wire_format.md
@@ -1,4 +1,4 @@
-# Data Tamer wire format (schema version 4)
+# Data Tamer wire format (schema version 5)
 
 This document is the normative description of the bytes Data Tamer produces.
 Anyone can implement a decoder in any language from it without reading the C++
@@ -14,10 +14,17 @@ sources. Two artifacts keep it honest:
 
 A change to any byte described here is a format revision: bump `SCHEMA_VERSION`
 in `data_tamer/types.hpp`, `data_tamer_parser/data_tamer_parser.hpp` and
-`python/data_tamer_parser.py`, regenerate the vectors with
+`python/data_tamer_parser.py` (and the version history below), regenerate the vectors with
 `DATA_TAMER_UPDATE_GOLDEN=1 datatamer_test --gtest_filter='WireFormat.*'`,
 update `expected.json` by hand (it is the oracle, never generated), update the
 Python decoder, and describe the change in this file.
+
+### Version history
+
+| Version | Change |
+|---:|---|
+| 5 | Hash defined as FNV-1a 64 of the schema text; covers custom type bodies. |
+| 4 | Lower-case type names, `MSG:` sections. Hash was `std::hash` based. |
 
 ## 1. Data model
 
@@ -69,7 +76,7 @@ The schema is UTF-8 text, one item per line, `\n` terminated. Decoders must
 trim spaces and `\r` at both ends of a line and skip empty lines.
 
 ```
-### version: 4
+### version: 5
 ### hash: <uint64>
 ### channel_name: wire_test
 
@@ -89,12 +96,14 @@ Point3D position
 uint32 stamp
 ```
 
-(Abridged: the complete text, with the real hash, is
+(Abridged: the complete text, with its hash, is
 `docs/wire_format/vectors/schema.txt`.)
 
 Grammar, in the order lines appear:
 
-1. `### version: <int>` – must equal 4. Reject other values.
+1. `### version: <int>` – 5 for texts written by this version. Decoders must
+   also accept 4, which differs only in how the hash was computed (see section
+   5), and reject anything else.
 2. `### hash: <uint64>` – the schema hash, see section 5.
 3. `### channel_name: <text>` – everything after the first space following the
    colon, trimmed. May contain spaces.
@@ -204,24 +213,32 @@ Two topics under a user-chosen prefix:
 
 ## 5. Schema hash
 
-`schema_hash` identifies a schema within one recording or one ROS session. It
-is computed by the writer from the channel name and the top-level fields with
-`std::hash`, whose result is **implementation-defined**: the same schema hashes
-differently under libstdc++ and libc++, and may change between compiler
-releases. Decoders therefore match a snapshot to a schema by comparing the
-snapshot's hash with the `### hash:` line of the schema shipped next to it
-(MCAP: the schema record attached to the channel; ROS: the `Schemas` entry) and
-never recompute it. Custom type bodies do not contribute to the hash.
+`schema_hash` identifies a schema within one recording or one ROS session:
+`MCAPSink` maps it to a channel, the ROS subscriber maps it to a schema text.
+It is defined byte for byte so that any decoder can verify it:
 
-For reference, the writer's algorithm is `AddFieldToHash` in
-`data_tamer/types.hpp`: start from `std::hash<std::string>(channel_name)`, then
-for each top-level field fold in name, type id, type name (custom types only),
-`is_vector` and `array_size` with the boost `hash_combine` recipe. The bundled
-C++ parser takes `Schema::hash` from the `### hash:` line; its opt-in
-`check_hash` recomputes the value and is only valid when reader and writer share
-a standard library. The golden `schema.txt`
-carries the hash of the machine that generated it, and the C++ golden test
-ignores that line when comparing.
+    schema_hash = FNV-1a-64( schema text with the "### hash:" line removed )
+
+with the standard FNV-1a 64-bit parameters, offset basis `0xcbf29ce484222325`
+and prime `0x100000001b3`, applied to the UTF-8 bytes of the text exactly as
+written by the producer (section 2), minus the whole `### hash: ...` line and
+its terminating newline. Everything else contributes: version, channel name,
+top-level fields, custom type sections and opaque encodings. Two schemas that
+differ anywhere, including inside a custom type body, have different hashes,
+and the same schema hashes identically on every platform.
+
+Decoders match a snapshot to a schema by comparing the snapshot's hash with the
+`### hash:` line of the schema shipped next to it (MCAP: the schema record
+attached to the channel; ROS: the `Schemas` entry). Verification against the
+recomputed value is optional (`check_hash` in the C++ parser, `verify_hash` in
+the Python decoder) and only meaningful for version 5 texts.
+
+**Version 4 texts** carried a hash computed with `std::hash`, which is
+implementation-defined and did not cover custom type bodies. Readers handle
+them by trusting the declared value, as before; they cannot be verified.
+Parsers older than version 5 recompute the version-4 hash themselves and
+therefore reject version 5 files with "Wrong SCHEMA_VERSION" instead of
+decoding them wrongly.
 
 ## 6. Worked example
 
@@ -266,7 +283,8 @@ same relative position.
 ## 7. Conformance
 
 A decoder conforms when it reproduces `expected.json` from the vectors
-directory the way `python/test_data_tamer_parser.py` does: parse `schema.txt`,
+directory the way `python/test_data_tamer_parser.py` does: parse `schema.txt`
+and recompute its hash,
 decode both snapshots from mask and payload (disabled fields absent, not zero;
 floats compared bit-exactly), split both `.mcap_message` bodies into the same
 mask and payload bytes, and reject a payload with trailing bytes or a schema

--- a/docs/wire_format.md
+++ b/docs/wire_format.md
@@ -234,8 +234,9 @@ recomputed value is optional (`check_hash` in the C++ parser, `verify_hash` in
 the Python decoder) and only meaningful for version 5 texts.
 
 **Version 4 texts** carried a hash computed with `std::hash`, which is
-implementation-defined and did not cover custom type bodies. Readers handle
-them by trusting the declared value, as before; they cannot be verified.
+implementation-defined and did not cover custom type bodies. Readers match them
+by the declared value; the C++ parser still recomputes the version 4 recipe for
+`check_hash`, which only agrees on the writer's platform.
 Parsers older than version 5 recompute the version-4 hash themselves and
 therefore reject version 5 files with "Wrong SCHEMA_VERSION" instead of
 decoding them wrongly.

--- a/docs/wire_format/vectors/schema.txt
+++ b/docs/wire_format/vectors/schema.txt
@@ -1,5 +1,5 @@
-### version: 4
-### hash: 64186643224329035
+### version: 5
+### hash: 11691003255120904065
 ### channel_name: wire_test
 
 bool flag

--- a/python/data_tamer_parser.py
+++ b/python/data_tamer_parser.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 import struct
 from dataclasses import dataclass, field
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
+_READABLE_VERSIONS = (4, 5)  # 4 differs only in how its hash was computed
 
 # Basic type name -> little-endian struct; the order is the BasicType id order.
 _STRUCT = {
@@ -62,8 +63,21 @@ def _parse_field_line(line: str) -> Field:
     return Field(name, type_part[:bracket], True, int(inner) if inner else 0)
 
 
-def parse_schema(text: str) -> Schema:
-    """Parse the schema text stored in the MCAP schema record / Schema.msg."""
+def schema_hash(text: str) -> int:
+    """FNV-1a 64 of the schema text with its '### hash:' line removed (spec section 5)."""
+    lines = [l for l in text.split("\n") if not l.startswith("### hash:")]
+    h = 0xCBF29CE484222325
+    for byte in "\n".join(lines).encode("utf-8"):
+        h = ((h ^ byte) * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+    return h
+
+
+def parse_schema(text: str, verify_hash: bool = False) -> Schema:
+    """Parse the schema text stored in the MCAP schema record / Schema.msg.
+
+    With verify_hash the declared hash must equal schema_hash(text); only version 5
+    texts can be verified.
+    """
     schema = Schema()
     lines = iter(text.splitlines())
     target = schema.fields
@@ -73,7 +87,7 @@ def parse_schema(text: str) -> Schema:
         if not line or line.startswith("====="):
             continue
         if line.startswith("### version:"):
-            if int(line.split(":", 1)[1]) != SCHEMA_VERSION:
+            if int(line.split(":", 1)[1]) not in _READABLE_VERSIONS:
                 raise ValueError(f"unsupported schema version in {line!r}")
         elif line.startswith("### hash:"):
             schema.hash = int(line.split(":", 1)[1])
@@ -89,6 +103,8 @@ def parse_schema(text: str) -> Schema:
             break
         else:
             target.append(_parse_field_line(line))
+    if verify_hash and schema.hash != schema_hash(text):
+        raise ValueError("schema hash does not match its text")
     return schema
 
 

--- a/python/test_data_tamer_parser.py
+++ b/python/test_data_tamer_parser.py
@@ -15,12 +15,12 @@ def read(name: str) -> bytes:
 class GoldenVectors(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.schema = dt.parse_schema(read("schema.txt").decode())
+        cls.schema = dt.parse_schema(read("schema.txt").decode(), verify_hash=True)
         cls.expected = json.loads(read("expected.json"))
 
     def test_schema(self):
         self.assertEqual(self.schema.channel_name, "wire_test")
-        self.assertGreater(self.schema.hash, 0)  # value is implementation-defined, see spec
+        self.assertEqual(self.schema.hash, dt.schema_hash(read("schema.txt").decode()))
         self.assertEqual([f.field_name for f in self.schema.fields], self.expected["fields"])
         self.assertEqual(sorted(self.schema.custom_types), ["Point3D", "Pose"])
 
@@ -43,6 +43,8 @@ class GoldenVectors(unittest.TestCase):
             dt.parse_snapshot(self.schema, read("snapshot_full.mask"), read("snapshot_full.payload") + b"\0")
         with self.assertRaises(ValueError):
             dt.parse_schema("### version: 3\n")
+        with self.assertRaises(ValueError):
+            dt.parse_schema("### version: 5\n### hash: 1\n### channel_name: x\n", verify_hash=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves the remaining item of #73 and the "implementation-defined hash" caveat introduced in #78.

## What changes

The schema hash becomes **FNV-1a 64 of the schema text with its own `### hash:` line removed**. Consequences:

- identical on every platform (no more `std::hash`), so any decoder can recompute and verify it;
- covers everything in the schema, including custom type bodies, so two schemas that differ only inside a struct no longer collide in a sink's hash-to-channel map;
- `SCHEMA_VERSION` bumps to **5**.

## Compatibility

- New readers (this header-only parser, the Python decoder) read version 4 files as before, through the declared hash, and can verify version 5 files (`check_hash` / `verify_hash=True`).
- Parsers older than this release recompute the version-4 hash themselves and would decode version 5 files wrongly; the version bump makes them fail explicitly with "Wrong SCHEMA_VERSION". PlotJuggler needs its `data_tamer` dependency bumped for the 2.0 release.

## Code

- `SchemaTextHash()` / `ComputeSchemaHash()` replace `AddFieldToHash` (library and parser).
- Hash recomputed at every registration and custom type addition (setup time only).
- Golden test now compares `schema.txt` byte for byte including the hash and checks `Schema::hash == SchemaTextHash(text)`; fixture regenerated. The Python test verifies the hash independently, so both implementations of FNV-1a agree on the real fixture.
- Spec section 5 rewritten as normative, version history added, changelog entry.

Targets `V2` together with #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)