### PR TITLE
MCAPSink: rollover counter before the file extension (#71)

### DIFF
--- a/data_tamer_cpp/src/sinks/mcap_sink.cpp
+++ b/data_tamer_cpp/src/sinks/mcap_sink.cpp
@@ -36,6 +36,22 @@ namespace DataTamer
 
 static constexpr char const* kDataTamer = "data_tamer";
 
+namespace
+{
+// "log.mcap" -> "log_3.mcap"; a path without an extension gets the suffix appended.
+std::string NumberedPath(const std::string& path, size_t number)
+{
+  const auto suffix = "_" + std::to_string(number);
+  const auto slash = path.find_last_of("/\\");
+  const auto dot = path.rfind('.');
+  if(dot == std::string::npos || (slash != std::string::npos && dot < slash))
+  {
+    return path + suffix;
+  }
+  return path.substr(0, dot) + suffix + path.substr(dot);
+}
+}  // namespace
+
 MCAPSink::MCAPSink(const std::string& filepath, bool do_compression)
   : filepath_(filepath), compression_(do_compression), original_filepath_(filepath)
 {
@@ -126,7 +142,7 @@ bool MCAPSink::storeSnapshot(const Snapshot& snapshot)
     if(create_file_on_reset_)
     {
       // change the current filepath to the original with "_[# resets]"" appended
-      filepath_ = original_filepath_ + "_" + std::to_string(file_reset_counter_);
+      filepath_ = NumberedPath(original_filepath_, file_reset_counter_);
       ++file_reset_counter_;
     }
     restartRecordingImpl(filepath_, compression_, false);

--- a/data_tamer_cpp/tests/dt_tests.cpp
+++ b/data_tamer_cpp/tests/dt_tests.cpp
@@ -323,3 +323,32 @@ TEST(DataTamerBasic, FinishQueue)
   // since we just stopped recording but not snapshots, we'll still be able to take a snapshot (but it won't be written to disk)
   EXPECT_TRUE(channel->takeSnapshot());
 }
+
+// #71: the rollover counter goes before the extension: log.mcap, log_1.mcap, ...
+TEST(DataTamerBasic, McapRolloverNumbersFilesBeforeTheExtension)
+{
+  const auto directory =
+      std::filesystem::temp_directory_path() /
+      ("data_tamer_rollover_" + std::to_string(NsecSinceEpoch().count()));
+  std::filesystem::remove_all(directory);
+  ASSERT_TRUE(std::filesystem::create_directory(directory));
+  auto channel = LogChannel::create("chan");
+  auto sink = std::make_shared<MCAPSink>((directory / "log.mcap").string());
+  sink->setCreateNewFileOnReset(true);
+  sink->setMaxTimeBeforeReset(std::chrono::seconds(-1));  // every snapshot rolls over
+  channel->addDataSink(sink);
+  double value = 1.0;
+  channel->registerValue("value", &value);
+  for(int i = 0; i < 3; ++i)
+  {
+    EXPECT_TRUE(channel->takeSnapshot());
+  }
+  sink->finishQueueAndStop();
+  for(const auto& file : std::filesystem::directory_iterator(directory))
+  {
+    EXPECT_EQ(file.path().extension(), ".mcap") << file.path();
+  }
+  EXPECT_TRUE(std::filesystem::exists(directory / "log.mcap"));
+  EXPECT_TRUE(std::filesystem::exists(directory / "log_1.mcap"));
+  std::filesystem::remove_all(directory);
+}


### PR DESCRIPTION
When `setCreateNewFileOnReset(true)` rolls the recording over, the counter was appended after the extension (`log.mcap_1`), which most tools do not recognise as an MCAP file. It now goes before it: `log.mcap`, `log_1.mcap`, `log_2.mcap`. A path without an extension keeps the appended suffix.

Test: rollover on every snapshot into a temp directory, then every file must have the `.mcap` extension and `log_1.mcap` must exist. Same change on `main`.

Closes #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)