### PR TITLE
Fix the correctness defects found by the 2.0 review

### DIFF
--- a/data_tamer_cpp/CHANGELOG.rst
+++ b/data_tamer_cpp/CHANGELOG.rst
@@ -4,6 +4,21 @@ Changelog for package data_tamer
 
 Unreleased
 ----------
+* Robustness fixes from the 2.0 review: the header-only parser and the Python
+  decoder check bounds before every read, reject masks shorter than the schema,
+  oversized dynamic counts and cyclic custom types, match type names exactly and
+  validate fixed-array extents; ``SchemaHash``/``schema_hash`` fields are
+  ``uint64_t`` end to end; ``TypeField::operator!=`` is defined. Library: the
+  fixed-size accumulator for arrays was uninitialized; custom types may now
+  contain numeric ``std::array``/``std::vector`` members; a failed registration
+  leaves the channel unchanged; null custom serializers are rejected; fixed
+  array extents outside 1..65535 fail to compile; the active mask is refreshed
+  under the write mutex so values enabled inside one transaction are captured
+  together; schema text is locale independent. ``MCAPSink`` reports write
+  failures from ``storeSnapshot()``, opens a new file before closing the old one
+  on restart, and synchronizes its setters with the worker. The ROS 2 sink
+  retries schema publication after a failure. ``ChannelsRegistry::clear()``
+  destroys channels outside its lock; ``addDefaultSink(nullptr)`` throws.
 * Schema version 5: the schema hash is FNV-1a 64 of the schema text (minus its
   own hash line), so it is identical on every platform, verifiable by any
   decoder and covers custom type bodies. Readers accept version 4 files through

--- a/data_tamer_cpp/include/data_tamer/channel.hpp
+++ b/data_tamer_cpp/include/data_tamer/channel.hpp
@@ -296,22 +296,36 @@ void LogChannel::updateTypeRegistryImpl(FieldsVector& fields, const char* field_
   using SerializeMe::container_info;
   TypeField field;
   field.field_name = field_name;
-  field.type = GetBasicType<T>();
 
-  if constexpr(GetBasicType<T>() == BasicType::OTHER)
+  if constexpr(container_info<T>::is_container)
   {
-    field.type_name = CustomTypeName<T>::get();
-
-    if constexpr(container_info<T>::is_container)
+    // A container member is described by its element type, like a top-level
+    // registerValue() of the same container: "float64[3] axis", "Pose[] poses".
+    using Type = typename container_info<T>::value_type;
+    field.is_vector = true;
+    field.array_size = container_info<T>::size;
+    field.type = GetBasicType<Type>();
+    if constexpr(GetBasicType<Type>() == BasicType::OTHER)
     {
-      field.is_vector = true;
-      field.array_size = container_info<T>::size;
-      using Type = typename container_info<T>::value_type;
+      field.type_name = CustomTypeName<Type>::get();
       updateTypeRegistry<Type>();
     }
     else
     {
+      field.type_name = ToStr(field.type);
+    }
+  }
+  else
+  {
+    field.type = GetBasicType<T>();
+    if constexpr(GetBasicType<T>() == BasicType::OTHER)
+    {
+      field.type_name = CustomTypeName<T>::get();
       updateTypeRegistry<T>();
+    }
+    else
+    {
+      field.type_name = ToStr(field.type);
     }
   }
   fields.push_back(field);
@@ -320,31 +334,31 @@ void LogChannel::updateTypeRegistryImpl(FieldsVector& fields, const char* field_
 template <typename T>
 inline void LogChannel::updateTypeRegistry()
 {
-  if constexpr(IsNumericType<T>())
+  if constexpr(!IsNumericType<
+                   T>())  // everything below must not be instantiated for numbers
   {
-    return;
-  }
-  using namespace SerializeMe;
-  static_assert(has_TypeDefinition<T>(), "Missing TypeDefinition");
+    using namespace SerializeMe;
+    static_assert(has_TypeDefinition<T>(), "Missing TypeDefinition");
 
-  FieldsVector fields;
-  const std::string type_name(CustomTypeName<T>::get());
-  if(schemaFrozen())
-  {
-    if(!hasCustomType(type_name))
-      throw std::runtime_error("Can't add a custom type after recording started");
-    return;
-  }
-  if(auto added_serializer = _type_registry.addType<T>(type_name, true))
-  {
-    auto func = [this, &fields](const char* field_name, const auto* member) {
-      using MemberType =
-          typename std::remove_cv_t<std::remove_reference_t<decltype(*member)>>;
-      updateTypeRegistryImpl<MemberType>(fields, field_name);
-    };
-    T dummy;
-    TypeDefinition(dummy, func);
-    addCustomType(type_name, fields);
+    FieldsVector fields;
+    const std::string type_name(CustomTypeName<T>::get());
+    if(schemaFrozen())
+    {
+      if(!hasCustomType(type_name))
+        throw std::runtime_error("Can't add a custom type after recording started");
+      return;
+    }
+    if(auto added_serializer = _type_registry.addType<T>(type_name, true))
+    {
+      auto func = [this, &fields](const char* field_name, const auto* member) {
+        using MemberType =
+            typename std::remove_cv_t<std::remove_reference_t<decltype(*member)>>;
+        updateTypeRegistryImpl<MemberType>(fields, field_name);
+      };
+      T dummy;
+      TypeDefinition(dummy, func);
+      addCustomType(type_name, fields);
+    }
   }
 }
 
@@ -383,7 +397,10 @@ inline RegistrationID LogChannel::registerCustomValue(const std::string& name,
 {
   std::lock_guard const lock(controlMutex());
   static_assert(!IsNumericType<T>(), "This method should be used only for custom types");
-
+  if(!serializer)
+  {
+    throw std::invalid_argument("registerCustomValue: the serializer can not be null");
+  }
   return registerValueImpl(name, ValuePtr(value_ptr, serializer), serializer);
 }
 

--- a/data_tamer_cpp/include/data_tamer/custom_types.hpp
+++ b/data_tamer_cpp/include/data_tamer/custom_types.hpp
@@ -123,7 +123,7 @@ inline void GetFixedSize(bool& is_fixed_size, size_t& fixed_size)
     else if constexpr(info.is_container && info.size >= 0)
     {
       // array
-      size_t obj_size;
+      size_t obj_size = 0;
       using Type = typename container_info<T>::value_type;
       GetFixedSize<Type>(is_fixed_size, obj_size);
       fixed_size += info.size * obj_size;

--- a/data_tamer_cpp/include/data_tamer/data_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/data_sink.hpp
@@ -30,7 +30,7 @@ struct Snapshot
   std::string_view channel_name;
 
   /// Unique identifier of the schema
-  std::size_t schema_hash;
+  uint64_t schema_hash;
 
   /// snapshot timestamp
   std::chrono::nanoseconds timestamp;

--- a/data_tamer_cpp/include/data_tamer/values.hpp
+++ b/data_tamer_cpp/include/data_tamer/values.hpp
@@ -14,9 +14,13 @@ using SerializeMe::has_TypeDefinition;
 namespace details
 {
 template <typename T>
-struct is_std_atomic : std::false_type {};
+struct is_std_atomic : std::false_type
+{
+};
 template <typename T>
-struct is_std_atomic<std::atomic<T>> : std::true_type {};
+struct is_std_atomic<std::atomic<T>> : std::true_type
+{
+};
 }  // namespace details
 
 /**
@@ -44,12 +48,14 @@ public:
   template <typename T, std::enable_if_t<IsNumericType<T>(), bool> = true>
   ValuePtr(const std::atomic<T>* pointer);
 
-  template <template <class, class> class Container, class T, class... TArgs,
-            std::enable_if_t<!has_TypeDefinition<Container<T, TArgs...>>::value, bool> = true>
+  template <
+      template <class, class> class Container, class T, class... TArgs,
+      std::enable_if_t<!has_TypeDefinition<Container<T, TArgs...>>::value, bool> = true>
   ValuePtr(const Container<T, TArgs...>* vect);
 
-  template <template <class, class> class Container, class T, class... TArgs,
-            std::enable_if_t<!has_TypeDefinition<Container<T, TArgs...>>::value, bool> = true>
+  template <
+      template <class, class> class Container, class T, class... TArgs,
+      std::enable_if_t<!has_TypeDefinition<Container<T, TArgs...>>::value, bool> = true>
   ValuePtr(const Container<T, TArgs...>* vect, CustomSerializer::Ptr type_info);
 
   template <typename T, size_t N,
@@ -97,11 +103,13 @@ private:
   uint16_t array_size_ = 0;
 
   // ---- the type-erased implementations ----
-  static void serializeNone(const void*, const CustomSerializer*, SerializeMe::SpanBytes&) {}
+  static void serializeNone(const void*, const CustomSerializer*, SerializeMe::SpanBytes&)
+  {}
   static size_t sizeNone(const void*, const CustomSerializer*) { return 0; }
 
   template <typename T>
-  static void serializeNumeric(const void* v, const CustomSerializer*, SerializeMe::SpanBytes& dst)
+  static void serializeNumeric(const void* v, const CustomSerializer*,
+                               SerializeMe::SpanBytes& dst)
   {
     std::memcpy(dst.data(), v, sizeof(T));
     dst.trimFront(sizeof(T));
@@ -113,14 +121,16 @@ private:
   }
 
   template <typename T>
-  static void serializeAtomic(const void* v, const CustomSerializer*, SerializeMe::SpanBytes& dst)
+  static void serializeAtomic(const void* v, const CustomSerializer*,
+                              SerializeMe::SpanBytes& dst)
   {
     const T tmp = static_cast<const std::atomic<T>*>(v)->load(std::memory_order_relaxed);
     std::memcpy(dst.data(), &tmp, sizeof(T));
     dst.trimFront(sizeof(T));
   }
 
-  static void serializeCustom(const void* v, const CustomSerializer* s, SerializeMe::SpanBytes& dst)
+  static void serializeCustom(const void* v, const CustomSerializer* s,
+                              SerializeMe::SpanBytes& dst)
   {
     s->serialize(v, dst);
   }
@@ -130,7 +140,8 @@ private:
   }
 
   template <typename C>
-  static void serializeContainer(const void* v, const CustomSerializer*, SerializeMe::SpanBytes& dst)
+  static void serializeContainer(const void* v, const CustomSerializer*,
+                                 SerializeMe::SpanBytes& dst)
   {
     SerializeMe::SerializeIntoBuffer(dst, *static_cast<const C*>(v));
   }
@@ -172,7 +183,8 @@ private:
   }
 
   template <typename A>
-  static void serializeArrayCustom(const void* v, const CustomSerializer* s, SerializeMe::SpanBytes& dst)
+  static void serializeArrayCustom(const void* v, const CustomSerializer* s,
+                                   SerializeMe::SpanBytes& dst)
   {
     for(const auto& value : *static_cast<const A*>(v))
     {
@@ -245,7 +257,8 @@ inline ValuePtr::ValuePtr(const Container<T, TArgs...>* vect)
 
 template <template <class, class> class Container, class T, class... TArgs,
           std::enable_if_t<!has_TypeDefinition<Container<T, TArgs...>>::value, bool>>
-inline ValuePtr::ValuePtr(const Container<T, TArgs...>* vect, CustomSerializer::Ptr type_info)
+inline ValuePtr::ValuePtr(const Container<T, TArgs...>* vect,
+                          CustomSerializer::Ptr type_info)
   : v_ptr_(vect)
   , serialize_fn_(&ValuePtr::serializeContainerCustom<Container<T, TArgs...>>)
   , size_fn_(&ValuePtr::sizeContainerCustom<Container<T, TArgs...>>)
@@ -255,7 +268,8 @@ inline ValuePtr::ValuePtr(const Container<T, TArgs...>* vect, CustomSerializer::
   , is_vector_(true)
 {}
 
-template <typename T, size_t N, std::enable_if_t<!has_TypeDefinition<std::array<T, N>>::value, bool>>
+template <typename T, size_t N,
+          std::enable_if_t<!has_TypeDefinition<std::array<T, N>>::value, bool>>
 inline ValuePtr::ValuePtr(const std::array<T, N>* array)
   : v_ptr_(array)
   , serialize_fn_(&ValuePtr::serializeContainer<std::array<T, N>>)
@@ -264,9 +278,13 @@ inline ValuePtr::ValuePtr(const std::array<T, N>* array)
   , type_(GetBasicType<T>())
   , is_vector_(true)
   , array_size_(N)
-{}
+{
+  static_assert(N >= 1 && N <= 65535, "fixed array extent must be in 1..65535 (wire "
+                                      "format)");
+}
 
-template <typename T, size_t N, std::enable_if_t<!has_TypeDefinition<std::array<T, N>>::value, bool>>
+template <typename T, size_t N,
+          std::enable_if_t<!has_TypeDefinition<std::array<T, N>>::value, bool>>
 inline ValuePtr::ValuePtr(const std::array<T, N>* array, CustomSerializer::Ptr type_info)
   : v_ptr_(array)
   , serialize_fn_(&ValuePtr::serializeArrayCustom<std::array<T, N>>)
@@ -276,7 +294,10 @@ inline ValuePtr::ValuePtr(const std::array<T, N>* array, CustomSerializer::Ptr t
   , type_(GetBasicType<T>())
   , is_vector_(true)
   , array_size_(N)
-{}
+{
+  static_assert(N >= 1 && N <= 65535, "fixed array extent must be in 1..65535 (wire "
+                                      "format)");
+}
 
 inline bool ValuePtr::operator==(const ValuePtr& other) const
 {

--- a/data_tamer_cpp/include/data_tamer_parser/data_tamer_parser.hpp
+++ b/data_tamer_cpp/include/data_tamer_parser/data_tamer_parser.hpp
@@ -52,6 +52,10 @@ struct BufferSpan
 
   void trimFront(size_t n)
   {
+    if(n > size)
+    {
+      throw std::runtime_error("DataTamerParser: payload truncated");
+    }
     data += n;
     size -= n;
   }
@@ -89,7 +93,7 @@ struct Schema
 struct SnapshotView
 {
   /// Unique identifier of the schema
-  size_t schema_hash;
+  uint64_t schema_hash;
 
   /// snapshot timestamp
   uint64_t timestamp;
@@ -128,12 +132,12 @@ inline T Deserialize(BufferSpan& buffer)
 {
   T var;
   const auto N = sizeof(T);
-  std::memcpy(&var, buffer.data, N);
-  buffer.data += N;
   if(N > buffer.size)
   {
-    throw std::runtime_error("Buffer overflow");
+    throw std::runtime_error("DataTamerParser: payload truncated");
   }
+  std::memcpy(&var, buffer.data, N);
+  buffer.data += N;
   buffer.size -= N;
   return var;
 }
@@ -180,6 +184,10 @@ inline VarNumber DeserializeToVarNumber(BasicType type, BufferSpan& buffer)
 
 inline bool GetBit(BufferSpan mask, size_t index)
 {
+  if((index >> 3) >= mask.size)
+  {
+    throw std::runtime_error("DataTamerParser: active mask shorter than the schema");
+  }
   const uint8_t& byte = mask.data[index >> 3];
   return 0 != (byte & uint8_t(1 << (index % 8)));
 }
@@ -242,6 +250,11 @@ inline bool TypeField::operator==(const TypeField& other) const
   return is_vector == other.is_vector && type == other.type &&
          array_size == other.array_size && field_name == other.field_name &&
          type_name == other.type_name;
+}
+
+inline bool TypeField::operator!=(const TypeField& other) const
+{
+  return !(*this == other);
 }
 
 inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false)
@@ -320,7 +333,7 @@ inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false
     if(str_left == "### hash:")
     {
       // check compatibility
-      declared_schema = std::stoul(str_right);
+      declared_schema = std::stoull(str_right);
       continue;
     }
 
@@ -344,14 +357,19 @@ inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false
       "UINT32", "INT64", "UINT64", "FLOAT", "DOUBLE", "OTHER"
     };
 
+    // The type token is everything before an optional "[...]": compare it exactly,
+    // otherwise a custom type named e.g. "float64Pose" would parse as float64.
+    auto typeToken = [](const std::string& spec) {
+      return spec.substr(0, spec.find('['));
+    };
     for(size_t i = 0; i < TypesCount; i++)
     {
-      if(str_left.find(kNamesNew[i]) == 0)
+      if(typeToken(str_left) == kNamesNew[i])
       {
         field.type = static_cast<BasicType>(i);
         break;
       }
-      if(str_right.find(kNamesOld[i]) == 0)
+      if(typeToken(str_right) == kNamesOld[i])
       {
         field.type = static_cast<BasicType>(i);
         std::swap(str_type, str_name);
@@ -373,11 +391,24 @@ inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false
     {
       field.is_vector = true;
       auto pos = str_type->find(']', offset);
+      if(pos == std::string::npos)
+      {
+        throw std::runtime_error("Unterminated array size in: " + line);
+      }
       if(pos != offset + 1)
       {
-        // get number
-        std::string number_string = line.substr(offset + 1, pos - offset - 1);
-        field.array_size = static_cast<uint16_t>(std::stoi(number_string));
+        const std::string number_string = str_type->substr(offset + 1, pos - offset - 1);
+        if(number_string.empty() ||
+           number_string.find_first_not_of("0123456789") != std::string::npos)
+        {
+          throw std::runtime_error("Invalid array size in: " + line);
+        }
+        const unsigned long long extent = std::stoull(number_string);
+        if(extent == 0 || extent > 65535)
+        {
+          throw std::runtime_error("Array size out of range (1..65535) in: " + line);
+        }
+        field.array_size = static_cast<uint16_t>(extent);
       }
     }
 
@@ -402,17 +433,55 @@ inline Schema BuilSchemaFromText(const std::string& txt, bool check_hash = false
   return schema;
 }
 
+/// Wire size in bytes of a basic type (0 for OTHER).
+inline size_t SizeOf(BasicType type)
+{
+  switch(type)
+  {
+    case BasicType::BOOL:
+    case BasicType::CHAR:
+    case BasicType::INT8:
+    case BasicType::UINT8:
+      return 1;
+    case BasicType::INT16:
+    case BasicType::UINT16:
+      return 2;
+    case BasicType::INT32:
+    case BasicType::UINT32:
+    case BasicType::FLOAT32:
+      return 4;
+    case BasicType::INT64:
+    case BasicType::UINT64:
+    case BasicType::FLOAT64:
+      return 8;
+    default:
+      return 0;
+  }
+}
+
+/// Nested custom types deeper than this are treated as a malformed (cyclic) schema.
+constexpr int kMaxSchemaDepth = 64;
+
 template <typename NumberCallback>
 bool ParseSnapshotRecursive(const TypeField& field,
                             const std::map<std::string, FieldsVector>& types_list,
                             BufferSpan& buffer, const NumberCallback& callback_number,
-                            const std::string& prefix)
+                            const std::string& prefix, int depth = 0)
 {
-  [[maybe_unused]] uint32_t vect_size = field.array_size;
+  if(depth > kMaxSchemaDepth)
+  {
+    throw std::runtime_error("DataTamerParser: custom types nested too deeply (cycle?)");
+  }
+  uint32_t vect_size = field.array_size;
   if(field.is_vector && field.array_size == 0)
   {
-    // dynamic vector
+    // dynamic vector: the count cannot exceed what the payload can hold
     vect_size = Deserialize<uint32_t>(buffer);
+    if(field.type != BasicType::OTHER &&
+       size_t(vect_size) * SizeOf(field.type) > buffer.size)
+    {
+      throw std::runtime_error("DataTamerParser: payload truncated");
+    }
   }
 
   auto new_prefix =
@@ -426,10 +495,15 @@ bool ParseSnapshotRecursive(const TypeField& field,
     }
     else
     {
-      const FieldsVector& fields = types_list.at(field.type_name);
-      for(const auto& sub_field : fields)
+      const auto type_it = types_list.find(field.type_name);
+      if(type_it == types_list.end())
       {
-        ParseSnapshotRecursive(sub_field, types_list, buffer, callback_number, var_name);
+        throw std::runtime_error("DataTamerParser: unknown type " + field.type_name);
+      }
+      for(const auto& sub_field : type_it->second)
+      {
+        ParseSnapshotRecursive(sub_field, types_list, buffer, callback_number, var_name,
+                               depth + 1);
       }
     }
   };
@@ -459,6 +533,10 @@ inline bool ParseSnapshot(const Schema& schema, SnapshotView snapshot,
     return false;
   }
   BufferSpan buffer = snapshot.payload;
+  if(snapshot.active_mask.size * 8 < schema.fields.size())
+  {
+    throw std::runtime_error("DataTamerParser: active mask shorter than the schema");
+  }
 
   for(size_t i = 0; i < schema.fields.size(); i++)
   {

--- a/data_tamer_cpp/src/channel.cpp
+++ b/data_tamer_cpp/src/channel.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <array>
 #include <limits>
+#include <optional>
 #include <thread>
 #include <unordered_map>
 
@@ -138,6 +139,14 @@ RegistrationID LogChannel::registerValueImpl(const std::string& name,
     const std::string type_name = type_info ? type_info->typeName() : ToStr(type);
     TypeField field{ name, type, type_name, value_ptr.isVector(),
                      value_ptr.vectorSize() };
+    // User code (typeSchema) runs before anything is published, so a throw
+    // leaves the channel exactly as it was.
+    std::optional<CustomSchema> custom_schema;
+    if(type_info && _p->schema.custom_types.count(type_info->typeName()) == 0)
+      custom_schema = type_info->typeSchema();
+    _p->series.reserve(_p->series.size() + 1);
+    _p->schema.fields.reserve(_p->schema.fields.size() + 1);
+
     Pimpl::ValueHolder instance;
     instance.name = name;
     instance.holder = std::move(value_ptr);
@@ -145,15 +154,9 @@ RegistrationID LogChannel::registerValueImpl(const std::string& name,
     _p->shared->addSeries();
     const size_t index = _p->series.size() - 1;
     _p->registered_values.insert({ name, index });
-
     _p->schema.fields.emplace_back(std::move(field));
-    if(type_info)
-    {
-      auto custom_schema = type_info->typeSchema();
-      if(custom_schema && _p->schema.custom_types.count(type_info->typeName()) == 0)
-        _p->schema.custom_schemas.insert({ type_info->typeName(), *custom_schema });
-    }
-
+    if(custom_schema)
+      _p->schema.custom_schemas.insert({ type_info->typeName(), *custom_schema });
     _p->schema.hash = ComputeSchemaHash(_p->schema);
     return { index, 1 };
   }
@@ -430,16 +433,17 @@ bool LogChannel::takeSnapshot(std::chrono::nanoseconds timestamp)
   SnapshotRef parent(_p->pool, slot);
   auto& snapshot = slot->snapshot;
 
-  // A rebuilt active bit acquires registration's initialized holder through
-  // its SC flag load; see refreshMaskIfDirty() for the ordering argument.
-  _p->refreshMaskIfDirty();
-
   {
     auto& write_mutex = _p->shared->write_mutex;
     uint64_t blocked_wait_ns = 0;
     const bool blocked =
         write_mutex.lockWithSpin(WriteMutex::kLockSpinNs, &blocked_wait_ns);
     std::lock_guard<WriteMutex> write_lock(write_mutex, std::adopt_lock);
+    // Under the write mutex, so enable changes made inside a scopedWrite()
+    // transaction are seen together with the values they belong to. A rebuilt
+    // active bit acquires registration's initialized holder through its SC flag
+    // load; see refreshMaskIfDirty() for the ordering argument.
+    _p->refreshMaskIfDirty();
     if(blocked)
     {
       _p->write_lock_contended.fetch_add(1, std::memory_order_relaxed);

--- a/data_tamer_cpp/src/data_tamer.cpp
+++ b/data_tamer_cpp/src/data_tamer.cpp
@@ -1,6 +1,7 @@
 #include "data_tamer/data_tamer.hpp"
 
 #include <memory>
+#include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -26,8 +27,10 @@ ChannelsRegistry& ChannelsRegistry::Global()
 
 void ChannelsRegistry::addDefaultSink(std::shared_ptr<DataSinkBase> sink)
 {
+  if(!sink)
+    throw std::invalid_argument("addDefaultSink: null sink");
   std::scoped_lock lk(_p->mutex);
-  _p->default_sinks.insert(sink);
+  _p->default_sinks.insert(std::move(sink));
 }
 
 std::shared_ptr<LogChannel> ChannelsRegistry::getChannel(std::string const& channel_name)
@@ -49,9 +52,15 @@ std::shared_ptr<LogChannel> ChannelsRegistry::getChannel(std::string const& chan
 
 void ChannelsRegistry::clear()
 {
-  std::scoped_lock lk(_p->mutex);
-  _p->channels.clear();
-  _p->default_sinks.clear();
+  // Destroying channels and sinks can block (they drain and join): never do
+  // that while holding the registry lock.
+  decltype(_p->channels) channels;
+  decltype(_p->default_sinks) sinks;
+  {
+    std::scoped_lock lk(_p->mutex);
+    channels.swap(_p->channels);
+    sinks.swap(_p->default_sinks);
+  }
 }
 
 }  // namespace DataTamer

--- a/data_tamer_cpp/src/sinks/mcap_sink.cpp
+++ b/data_tamer_cpp/src/sinks/mcap_sink.cpp
@@ -70,17 +70,18 @@ MCAPSink::MCAPSink(const std::string& filepath, bool do_compression,
 void DataTamer::MCAPSink::openFile(std::string const& filepath)
 {
   std::scoped_lock lk(_p->mutex);
-  _p->writer = std::make_unique<mcap::McapWriter>();
+  // Open the new file first: if that fails the current recording stays intact.
+  auto writer = std::make_unique<mcap::McapWriter>();
   mcap::McapWriterOptions options(kDataTamer);
   options.compression =
       _p->compression ? mcap::Compression::Zstd : mcap::Compression::None;
-  auto status = _p->writer->open(filepath, options);
+  const auto status = writer->open(filepath, options);
   if(!status.ok())
   {
-    throw std::runtime_error("Failed to open MCAP file for writing");
+    throw std::runtime_error("Failed to open MCAP file for writing: " + status.message);
   }
+  _p->writer = std::move(writer);  // closes the previous file
   _p->start_time = std::chrono::system_clock::now();
-  // clean up, in case this was opened a second time
   _p->hash_to_channel_id.clear();
 }
 
@@ -142,7 +143,7 @@ bool MCAPSink::storeSnapshot(const Snapshot& snapshot)
   msg.publishTime = msg.logTime;
   msg.data = reinterpret_cast<std::byte const*>(merged_payload.data());  // NOLINT
   msg.dataSize = merged_payload.size();
-  auto status = _p->writer->write(msg);
+  const bool written = _p->writer->write(msg).ok();
 
   // If reset_time is exceeded, we want to overwrite the current file.
   // Better than filling the disk, if you forgot to stop the application.
@@ -157,16 +158,18 @@ bool MCAPSink::storeSnapshot(const Snapshot& snapshot)
     }
     restartRecordingImpl(_p->filepath, _p->compression, false);
   }
-  return true;
+  return written;
 }
 
 void MCAPSink::setMaxTimeBeforeReset(std::chrono::seconds reset_time)
 {
+  std::scoped_lock lk(_p->mutex);  // read by the worker in storeSnapshot
   _p->reset_time = reset_time;
 }
 
 void MCAPSink::setCreateNewFileOnReset(bool create_file_on_reset)
 {
+  std::scoped_lock lk(_p->mutex);
   _p->create_file_on_reset = create_file_on_reset;
 }
 

--- a/data_tamer_cpp/src/sinks/ros2_publisher_sink.cpp
+++ b/data_tamer_cpp/src/sinks/ros2_publisher_sink.cpp
@@ -67,7 +67,6 @@ bool ROS2PublisherSink::storeSnapshot(const Snapshot& snapshot)
     std::scoped_lock lk(_p->schema_mutex);
     if(_p->schema_changed)
     {
-      _p->schema_changed = false;
       data_tamer_msgs::msg::Schemas msg;
       msg.schemas.reserve(_p->schemas.size());
 
@@ -83,6 +82,7 @@ bool ROS2PublisherSink::storeSnapshot(const Snapshot& snapshot)
         msg.schemas.push_back(std::move(schema_msg));
       }
       _p->schema_publisher->publish(msg);
+      _p->schema_changed = false;  // only once published; a throw leaves it pending
     }
   }
   //----------------------------------------

--- a/data_tamer_cpp/src/types.cpp
+++ b/data_tamer_cpp/src/types.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <limits>
 #include <map>
+#include <locale>
 #include <sstream>
 #include <unordered_map>
 
@@ -193,6 +194,7 @@ bool TypeField::operator!=(const TypeField& other) const
 std::string ToStr(const Schema& schema)
 {
   std::ostringstream ss;
+  ss.imbue(std::locale::classic());  // the hash covers this text: never locale-dependent
   ss << schema;
   return ss.str();
 }

--- a/data_tamer_cpp/tests/channel_control_tests.cpp
+++ b/data_tamer_cpp/tests/channel_control_tests.cpp
@@ -5,6 +5,7 @@
 #include <condition_variable>
 #include <cstring>
 #include <functional>
+#include <optional>
 #include <future>
 #include <thread>
 
@@ -69,7 +70,14 @@ public:
   mutable Gate* gate = nullptr;
   bool throw_size = false;
   bool throw_serialize = false;
+  bool throw_schema = false;
   mutable size_t size_calls = 0;
+  std::optional<CustomSchema> typeSchema() const override
+  {
+    if(throw_schema)
+      throw std::runtime_error("schema");
+    return std::nullopt;
+  }
   const std::string& typeName() const override
   {
     static const std::string name = "CustomValue";
@@ -79,13 +87,16 @@ public:
   size_t serializedSize(const void*) const override
   {
     ++size_calls;
-    if(gate) gate->pause();
-    if(throw_size) throw std::runtime_error("size");
+    if(gate)
+      gate->pause();
+    if(throw_size)
+      throw std::runtime_error("size");
     return 8;
   }
   void serialize(const void* source, SerializeMe::SpanBytes& bytes) const override
   {
-    if(throw_serialize) throw std::runtime_error("serialize");
+    if(throw_serialize)
+      throw std::runtime_error("serialize");
     const auto value = static_cast<const CustomValue*>(source)->value;
     std::memcpy(bytes.data(), &value, 8);
     bytes.trimFront(8);
@@ -107,15 +118,18 @@ public:
   std::function<void()> on_store;
   void addChannel(const std::string&, const Schema& value) override
   {
-    if(add_gate) add_gate->pause();
-    if(reject_schema) throw std::runtime_error("schema");
+    if(add_gate)
+      add_gate->pause();
+    if(reject_schema)
+      throw std::runtime_error("schema");
     ++registrations;
     schema = value;
   }
   bool storeSnapshot(const Snapshot& value) override
   {
     snapshots.push_back(value);
-    if(on_store) on_store();
+    if(on_store)
+      on_store();
     return true;
   }
 };
@@ -229,8 +243,11 @@ TEST(ChannelControl, UnregisterWaitsForPausedReaderBeforeValueDestruction)
   serializer->gate = &gate;
   auto snapshot = std::async(std::launch::async, [&] { return channel->takeSnapshot(); });
   EXPECT_TRUE(gate.wait());
-  std::atomic<bool> returned{false};
-  auto removal = std::async(std::launch::async, [&] { channel->unregister(id); returned = true; });
+  std::atomic<bool> returned{ false };
+  auto removal = std::async(std::launch::async, [&] {
+    channel->unregister(id);
+    returned = true;
+  });
   // Observing cleared liveness establishes that removal reached its publication.
   const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
   while(channel->sharedState()->isEnabled(id.first_index) &&
@@ -373,12 +390,12 @@ TEST(ChannelControl, ConcurrentChurnTogglesAndSinkChangesPreservePayloads)
   channel->addDataSink(stable);
   ASSERT_TRUE(channel->takeSnapshot());
   // Reuse the same registered type from two independent controller threads.
-  std::atomic<bool> done{false};
+  std::atomic<bool> done{ false };
   std::thread toggler([&] {
     while(!done)
     {
-      channel->setEnabled({0, 3}, false);
-      channel->setEnabled({0, 3}, true);
+      channel->setEnabled({ 0, 3 }, false);
+      channel->setEnabled({ 0, 3 }, true);
     }
   });
   std::thread second_control([&] {
@@ -418,7 +435,7 @@ TEST(ChannelControl, ConcurrentChurnTogglesAndSinkChangesPreservePayloads)
 
 TEST(ChannelControl, SerializerExceptionsLeaveEpochAndPoolReusable)
 {
-  for(bool size_pass : {false, true})
+  for(bool size_pass : { false, true })
   {
     auto channel = LogChannel::create("control");
     auto sink = std::make_shared<ControlSink>();
@@ -452,8 +469,25 @@ TEST(ChannelControl, ExhaustedPoolDoesNotCallSerializer)
   auto serializer = std::make_shared<PausedSerializer>();
   channel->registerCustomValue("value", &value, serializer);
   channel->addDataSink(sink);
-  for(size_t i = 0; i < SnapshotPool::kDefaultCapacity; ++i) ASSERT_TRUE(channel->takeSnapshot());
+  for(size_t i = 0; i < SnapshotPool::kDefaultCapacity; ++i)
+    ASSERT_TRUE(channel->takeSnapshot());
   const auto calls = serializer->size_calls;
   EXPECT_FALSE(channel->takeSnapshot());
   EXPECT_EQ(serializer->size_calls, calls);
+}
+
+TEST(ChannelControl, FailedRegistrationLeavesTheChannelUnchanged)
+{
+  auto channel = LogChannel::create("control");
+  CustomValue value;
+  auto serializer = std::make_shared<PausedSerializer>();
+  serializer->throw_schema = true;
+  EXPECT_THROW(channel->registerCustomValue("value", &value, serializer),
+               std::runtime_error);
+  EXPECT_TRUE(channel->getSchema().fields.empty());
+  serializer->throw_schema = false;
+  EXPECT_NO_THROW(channel->registerCustomValue("value", &value, serializer));
+  EXPECT_EQ(channel->getSchema().fields.size(), 1u);
+  EXPECT_THROW(channel->registerCustomValue("other", &value, CustomSerializer::Ptr{}),
+               std::invalid_argument);
 }

--- a/data_tamer_cpp/tests/custom_types_tests.cpp
+++ b/data_tamer_cpp/tests/custom_types_tests.cpp
@@ -304,3 +304,43 @@ TEST(DataTamerCustom, RegisterConstMethods)
   ASSERT_TRUE(std::string::npos != posB);
   ASSERT_LT(posA, posB);
 }
+
+struct Wheel
+{
+  std::array<double, 3> axis = { 1, 2, 3 };
+  std::array<int32_t, 2> ticks = { 4, 5 };
+};
+template <class AddField>
+std::string_view TypeDefinition(Wheel& w, AddField& add)
+{
+  add("axis", &w.axis);
+  add("ticks", &w.ticks);
+  return "Wheel";
+}
+struct Chassis
+{
+  std::array<Wheel, 4> wheels;
+  double mass = 10;
+};
+template <class AddField>
+std::string_view TypeDefinition(Chassis& c, AddField& add)
+{
+  add("wheels", &c.wheels);
+  add("mass", &c.mass);
+  return "Chassis";
+}
+
+// The fixed-size accumulator for arrays was uninitialized; the cached size must
+// match the bytes actually written, including nested fixed arrays of structs.
+TEST(DataTamerCustom, FixedSizeOfNestedFixedArraysMatchesPayload)
+{
+  auto channel = LogChannel::create("chan");
+  auto sink = std::make_shared<DummySink>();
+  channel->addDataSink(sink);
+  Chassis chassis;
+  channel->registerValue("chassis", &chassis);
+  ASSERT_TRUE(channel->takeSnapshot());
+  sink->flush();
+  const size_t expected = 4 * (3 * sizeof(double) + 2 * sizeof(int32_t)) + sizeof(double);
+  EXPECT_EQ(sink->latestPayloadSize(), expected);
+}

--- a/data_tamer_cpp/tests/parser_tests.cpp
+++ b/data_tamer_cpp/tests/parser_tests.cpp
@@ -357,10 +357,25 @@ TEST(DataTamerParser, RejectsMalformedInput)
                      { snapshot.payload.data(), snapshot.payload.size() } };
   ASSERT_TRUE(ParseSnapshot(schema, view, count_values));
 
-  // truncated payload: the last double is cut in half
+  // truncated payload: the last double is cut in half; the checked read reports it
   SnapshotView truncated = view;
   truncated.payload.size -= 4;
-  EXPECT_THROW(ParseSnapshot(schema, truncated, count_values), std::runtime_error);
+  try
+  {
+    ParseSnapshot(schema, truncated, count_values);
+    FAIL() << "truncated payload accepted";
+  }
+  catch(const std::runtime_error& e)
+  {
+    EXPECT_NE(std::string(e.what()).find("truncated"), std::string::npos) << e.what();
+  }
+  static_assert(sizeof(SnapshotView::schema_hash) == 8, "schema hash must be 64-bit "
+                                                        "everywhere");
+  static_assert(sizeof(DataTamer::Snapshot::schema_hash) == 8, "schema hash must be "
+                                                               "64-bit everywhere");
+  EXPECT_FALSE(schema.fields[0] !=
+               schema.fields[0]);  // operator!= must be defined (link check)
+  EXPECT_TRUE(schema.fields[0] != schema.fields[1]);
 
   // mask too short for the schema
   SnapshotView short_mask = view;

--- a/data_tamer_cpp/tests/parser_tests.cpp
+++ b/data_tamer_cpp/tests/parser_tests.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <thread>
 #include <variant>
+#include <cstring>
 #include <string>
 
 using namespace DataTamerParser;
@@ -331,4 +332,81 @@ TEST(DataTamerParser, ReadsAndVerifiesBothSchemaVersions)
   ASSERT_EQ(v4.custom_types.size(), v5.custom_types.size());
 
   EXPECT_THROW(BuilSchemaFromText("### version: 3\n"), std::runtime_error);
+}
+
+// Corrupt or hostile input must fail with an exception, never read out of bounds.
+TEST(DataTamerParser, RejectsMalformedInput)
+{
+  auto channel = DataTamer::LogChannel::create("chan");
+  Pose pose;
+  std::vector<double> samples = { 1.0, 2.0 };
+  channel->registerValue("pose", &pose);
+  channel->registerValue("samples", &samples);
+  auto sink = std::make_shared<DataTamer::DummySink>();
+  channel->addDataSink(sink);
+  ASSERT_TRUE(channel->takeSnapshot());
+  sink->flush();
+  const auto snapshot = sink->latestSnapshot();
+  const auto schema = BuilSchemaFromText(ToStr(channel->getSchema()));
+  auto count_values = [](const std::string&, const VarNumber&) {};
+
+  // intact
+  SnapshotView view{ snapshot.schema_hash,
+                     0,
+                     { snapshot.active_mask.data(), snapshot.active_mask.size() },
+                     { snapshot.payload.data(), snapshot.payload.size() } };
+  ASSERT_TRUE(ParseSnapshot(schema, view, count_values));
+
+  // truncated payload: the last double is cut in half
+  SnapshotView truncated = view;
+  truncated.payload.size -= 4;
+  EXPECT_THROW(ParseSnapshot(schema, truncated, count_values), std::runtime_error);
+
+  // mask too short for the schema
+  SnapshotView short_mask = view;
+  short_mask.active_mask.size = 0;
+  EXPECT_THROW(ParseSnapshot(schema, short_mask, count_values), std::runtime_error);
+
+  // dynamic vector whose count exceeds the payload
+  auto huge = snapshot.payload;
+  const size_t count_offset = huge.size() - 2 * sizeof(double) - sizeof(uint32_t);
+  const uint32_t bogus = 0xFFFFFFFFu;
+  std::memcpy(huge.data() + count_offset, &bogus, sizeof(bogus));
+  SnapshotView huge_view = view;
+  huge_view.payload = { huge.data(), huge.size() };
+  EXPECT_THROW(ParseSnapshot(schema, huge_view, count_values), std::runtime_error);
+
+  // a custom type name that merely starts with a primitive name is a custom type
+  const auto tricky = BuilSchemaFromText("### version: 5\n### hash: 1\n### channel_name: "
+                                         "c\n\n"
+                                         "float64Pose p\n"
+                                         "==============================================="
+                                         "============\n"
+                                         "MSG: float64Pose\nfloat64 x\n");
+  ASSERT_EQ(tricky.fields.size(), 1u);
+  EXPECT_EQ(tricky.fields[0].type, BasicType::OTHER);
+  EXPECT_EQ(tricky.fields[0].type_name, "float64Pose");
+
+  // a self-referencing custom type cannot be traversed forever
+  const auto cyclic = BuilSchemaFromText("### version: 5\n### hash: 1\n### channel_name: "
+                                         "c\n\n"
+                                         "Node root\n"
+                                         "==============================================="
+                                         "============\n"
+                                         "MSG: Node\nNode next\n");
+  const uint8_t one_bit = 1;
+  const uint8_t no_payload = 0;
+  SnapshotView cyclic_view{ 1, 0, { &one_bit, 1 }, { &no_payload, 0 } };
+  EXPECT_THROW(ParseSnapshot(cyclic, cyclic_view, count_values), std::runtime_error);
+
+  // malformed array extents
+  EXPECT_THROW(BuilSchemaFromText("### version: 5\n### hash: 1\n### channel_name: "
+                                  "c\n\nint32[0] a\n"),
+               std::runtime_error);
+  EXPECT_THROW(BuilSchemaFromText("### version: 5\n### hash: 1\n### channel_name: "
+                                  "c\n\nint32[70000] a\n"),
+               std::runtime_error);
+  EXPECT_THROW(BuilSchemaFromText("### version: 5\n### hash: 1\n### channel_name: "
+                                  "c\n\nint32[3 a\n"),
+               std::runtime_error);
 }

--- a/data_tamer_cpp/tests/sink_queue_tests.cpp
+++ b/data_tamer_cpp/tests/sink_queue_tests.cpp
@@ -433,3 +433,35 @@ TEST(SinkQueue, FastConsumerCannotReleaseParentBeforeSecondFanout)
   EXPECT_EQ(received[0].size(), accepted);
   EXPECT_EQ(received[0], received[1]);
 }
+
+// A restart whose file cannot be opened must throw and leave the current
+// recording running: the old writer is replaced only after the new one opened.
+TEST(SinkQueue, McapFailedRestartKeepsTheCurrentRecording)
+{
+  const auto directory =
+      std::filesystem::temp_directory_path() /
+      ("data_tamer_restart_" + std::to_string(NsecSinceEpoch().count()));
+  std::filesystem::remove_all(directory);
+  ASSERT_TRUE(std::filesystem::create_directory(directory));
+  const auto path = (directory / "log.mcap").string();
+  uint64_t value = 3;
+  auto sink = std::make_shared<MCAPSink>(path, false);
+  auto channel = channelWith(sink, &value);
+  ASSERT_TRUE(channel->takeSnapshot());
+  EXPECT_THROW(
+      sink->restartRecording((directory / "missing" / "dir" / "x.mcap").string()),
+      std::runtime_error);
+  ASSERT_TRUE(channel->takeSnapshot());  // still recording into the first file
+  sink->finishQueueAndStop();
+  mcap::McapReader reader;
+  ASSERT_TRUE(reader.open(path).ok());
+  size_t count = 0;
+  for(const auto& message : reader.readMessages())
+  {
+    (void)message;
+    ++count;
+  }
+  EXPECT_EQ(count, 2u);
+  reader.close();
+  std::filesystem::remove_all(directory);
+}

--- a/data_tamer_cpp/tests/transaction_tests.cpp
+++ b/data_tamer_cpp/tests/transaction_tests.cpp
@@ -9,12 +9,17 @@
 #include <functional>
 #include <condition_variable>
 #include <cstring>
+#include <fstream>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
 #include <type_traits>
 #include <vector>
+#if defined(__linux__)
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
 
 using namespace DataTamer;
 using DataTamerTest::AllocCounter;
@@ -443,4 +448,45 @@ TEST(Transaction, SerializationExceptionReleasesWriteMutex)
   ASSERT_THROW(channel->takeSnapshot(), std::runtime_error);
   ASSERT_TRUE(channel->writeMutex().try_lock());
   channel->writeMutex().unlock();
+}
+
+// Values enabled inside one transaction must appear together in the snapshot
+// that observes the transaction, never only the first of them.
+TEST(Transaction, ValuesEnabledInsideATransactionAppearTogether)
+{
+#if defined(__linux__)
+  if(!std::ifstream("/proc/self/stat"))
+    GTEST_SKIP() << "needs readable procfs";
+  auto channel = LogChannel::create("chan");
+  auto sink = std::make_shared<CheckingSink>(CheckingSink::Payload::PAIR);
+  channel->addDataSink(sink);
+  auto a = channel->createLoggedValue<double>("a", 1.0);
+  auto b = channel->createLoggedValue<double>("b", 1.0);
+  ASSERT_TRUE(channel->takeSnapshot());  // freeze; a valid pair
+  ASSERT_TRUE(sink->waitFor(1));
+  a->setEnabled(false);
+  b->setEnabled(false);
+
+  std::atomic<pid_t> tid{ 0 };
+  std::atomic<bool> finished{ false };
+  bool ok = false;
+  std::thread snapshotter;
+  {
+    auto tx = channel->scopedWrite();
+    a->set(2.0);  // enables a
+    snapshotter = std::thread([&] {
+      tid = static_cast<pid_t>(syscall(SYS_gettid));
+      ok = channel->takeSnapshot();  // blocks on the write mutex
+      finished = true;
+    });
+    ASSERT_TRUE(DataTamerTest::waitForSleepingThread(tid, finished));
+    b->set(2.0);  // enables b, still inside the transaction
+  }
+  snapshotter.join();
+  ASSERT_TRUE(ok);
+  ASSERT_TRUE(sink->waitFor(2));
+  EXPECT_EQ(sink->errors(), 0u);  // PAIR payload: both or neither, never one value
+#else
+  GTEST_SKIP() << "observing a blocked snapshot requires Linux procfs";
+#endif
 }

--- a/docs/wire_format.md
+++ b/docs/wire_format.md
@@ -136,7 +136,8 @@ decoders may ignore that.
 
 ### 3.1 Active mask
 
-`ceil(F / 8)` bytes for `F` top-level fields. Bit `i` of the mask is
+At least `ceil(F / 8)` bytes for `F` top-level fields; a shorter mask is a
+malformed snapshot and decoders must reject it. Bit `i` of the mask is
 `mask[i >> 3] & (1 << (i & 7))`: byte 0 holds fields 0 to 7, the least
 significant bit first. A set bit means the field is present in the payload.
 Bits beyond `F - 1` are unspecified (the writer currently sets them); ignore
@@ -164,7 +165,10 @@ decode_field(field):
 ```
 
 After the loop `pos` must equal the payload length; otherwise the schema and
-the payload do not belong together.
+the payload do not belong together. Decoders must check every read against the
+remaining payload before performing it, reject a dynamic count larger than the
+remaining bytes allow, and bound the nesting depth of custom types (the reference
+decoders use 64) so that a malformed or cyclic schema cannot recurse forever.
 
 Flattened series names, as produced by the reference decoders and PlotJuggler:
 nested fields join with `/`, container elements append `[i]`:
@@ -221,11 +225,13 @@ It is defined byte for byte so that any decoder can verify it:
 
 with the standard FNV-1a 64-bit parameters, offset basis `0xcbf29ce484222325`
 and prime `0x100000001b3`, applied to the UTF-8 bytes of the text exactly as
-written by the producer (section 2), minus the whole `### hash: ...` line and
-its terminating newline. Everything else contributes: version, channel name,
-top-level fields, custom type sections and opaque encodings. Two schemas that
-differ anywhere, including inside a custom type body, have different hashes,
-and the same schema hashes identically on every platform.
+written by the producer (section 2), minus the first line that starts with
+`### hash:` (the header line) and its terminating newline; a line inside an
+opaque schema body is not removed. Everything else contributes: version, channel
+name, top-level fields, custom type sections and opaque encodings. Any change
+to the schema, including inside a custom type body, changes the hash (up to the
+collision probability of a 64-bit hash), and the same schema hashes identically
+on every platform.
 
 Decoders match a snapshot to a schema by comparing the snapshot's hash with the
 `### hash:` line of the schema shipped next to it (MCAP: the schema record

--- a/python/data_tamer_parser.py
+++ b/python/data_tamer_parser.py
@@ -65,7 +65,11 @@ def _parse_field_line(line: str) -> Field:
 
 def schema_hash(text: str) -> int:
     """FNV-1a 64 of the schema text with its '### hash:' line removed (spec section 5)."""
-    lines = [l for l in text.split("\n") if not l.startswith("### hash:")]
+    lines = text.split("\n")
+    for i, l in enumerate(lines):  # exactly the header line, as the C++ writer does
+        if l.startswith("### hash:"):
+            del lines[i]
+            break
     h = 0xCBF29CE484222325
     for byte in "\n".join(lines).encode("utf-8"):
         h = ((h ^ byte) * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
@@ -108,7 +112,12 @@ def parse_schema(text: str, verify_hash: bool = False) -> Schema:
     return schema
 
 
+MAX_SCHEMA_DEPTH = 64  # deeper nesting is treated as a malformed (cyclic) schema
+
+
 def get_bit(mask: bytes, index: int) -> bool:
+    if (index >> 3) >= len(mask):
+        raise ValueError("active mask shorter than the schema")
     return bool(mask[index >> 3] & (1 << (index & 7)))
 
 
@@ -116,6 +125,9 @@ class _Reader:
     def __init__(self, data: bytes):
         self.data = data
         self.pos = 0
+
+    def remaining(self) -> int:
+        return len(self.data) - self.pos
 
     def number(self, type_name: str):
         fmt = _STRUCT[type_name]
@@ -126,13 +138,18 @@ class _Reader:
         return value.decode("latin-1") if type_name == "char" else value
 
 
-def _parse_field(f: Field, schema: Schema, reader: _Reader, prefix: str, out: dict) -> None:
+def _parse_field(f: Field, schema: Schema, reader: _Reader, prefix: str, out: dict,
+                 depth: int = 0) -> None:
+    if depth > MAX_SCHEMA_DEPTH:
+        raise ValueError("custom types nested too deeply (cyclic schema?)")
     name = f.field_name if not prefix else f"{prefix}/{f.field_name}"
     if f.is_vector:
         count = f.array_size or reader.number("uint32")  # dynamic vector: count prefix
-        names = [f"{name}[{i}]" for i in range(count)]
+        if f.is_basic and count * _STRUCT[f.type_name].size > reader.remaining():
+            raise ValueError("payload truncated")
+        names = (f"{name}[{i}]" for i in range(count))  # lazy: the count is untrusted
     else:
-        names = [name]
+        names = (name,)
     if f.is_basic:
         for n in names:
             out[n] = reader.number(f.type_name)
@@ -140,7 +157,7 @@ def _parse_field(f: Field, schema: Schema, reader: _Reader, prefix: str, out: di
         subs = schema.custom_types[f.type_name]
         for n in names:
             for sub in subs:
-                _parse_field(sub, schema, reader, n, out)
+                _parse_field(sub, schema, reader, n, out, depth + 1)
     else:
         raise ValueError(f"type {f.type_name!r} has an opaque encoding; cannot continue")
 


### PR DESCRIPTION
First of the three buckets from the V2 review (#85): the verified correctness defects, none of which changes the wire format or the intended API. The golden wire-format test passes unchanged.

## Parser (header-only) and Python decoder
- Bounds checked **before** every read: `trimFront`, `Deserialize`, `GetBit` throw on truncation instead of reading out of bounds.
- Mask shorter than the schema, dynamic count exceeding the payload, custom types nested deeper than 64 (cyclic schema), unknown type names: all rejected with a clear error.
- Type names matched exactly (`float64Pose` is a custom type); fixed-array extents validated (digits, 1..65535, terminated bracket).
- Hashes are `uint64_t` end to end (`Snapshot::schema_hash`, `SnapshotView::schema_hash`, `stoull`); `TypeField::operator!=` was declared but never defined.
- Python removes exactly the header hash line like the C++ writer, iterates untrusted counts lazily.

## Library
- `GetFixedSize` accumulated into an **uninitialized** `size_t` for fixed arrays.
- Custom types with numeric `std::array`/`std::vector` members did not compile (`static_assert` instantiated after an `if constexpr return`) and would have been described as `OTHER`; they are now `float64[3] axis` etc.
- A throwing `typeSchema()` left a half-registered value; user code now runs before anything is published. Null custom serializers throw `invalid_argument`.
- Fixed array extents outside 1..65535 are a compile error instead of a silent `uint16_t` narrowing.
- Active mask refreshed under the write mutex: values enabled inside one `scopedWrite()` are captured together (new test, mutation-checked: fails 5/5 with the old placement).
- Schema text uses the classic locale (the hash covers it).

## Sinks and registry
- `MCAPSink::storeSnapshot()` returns the write status; restart opens the new file before dropping the old writer (a failed open keeps the current recording); setters synchronize with the worker.
- ROS 2 sink clears `schema_changed` only after publishing succeeded.
- `ChannelsRegistry::clear()` destroys channels outside its lock; `addDefaultSink(nullptr)` throws.

Not in this PR (API decisions, tracked separately): delivery-stage result types, `set()` auto-enable default, snapshot result type, sink callback signature, file-reset default, `Stats` layout, name/path rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Regression coverage

Fails on the old code: mask refresh placement (mutation-checked 5/5), numeric containers in custom types (did not compile), uninitialized size accumulator (same test), failed registration, null serializer, prefix type names, cyclic types, short mask, invalid array extents, restart failure keeping the current recording, `operator!=` (link check), truncated payload (asserts the checked-read error message).

Only sanitizer-visible: the out-of-bounds read on truncated payloads and oversized counts also threw on the old code, after reading past the buffer; ASAN distinguishes the two, the assertion alone does not.

Not regression-tested: MCAP write-status propagation, setter synchronization (TSAN-only), ROS schema retry, registry `clear()` ordering, 32-bit hash width (compile-time assert only), locale independence.
