### PR TITLE
Sinks: composition (DataSink + SinkWorker), owning Snapshot, opaque SnapshotRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ DataTamer will forward the collected data to 1 or multiple **sinks**;
 a sink may save the information immediately in a file (currently, we support [MCAP](https://mcap.dev/))
 or publish it using an inter-process communication, for instance, a ROS2 publisher.
 
-You can easily create your own, specialized sinks.
+You can easily create your own, specialized sinks: implement `DataTamer::DataSink`
+(two callbacks, `onSchema` and `onSnapshot`) and wrap it with `SinkWorker::create<MySink>()`,
+which owns the delivery queue and thread. See `data_tamer/sinks/dummy_sink.hpp` for a small one.
 
 Use [PlotJuggler](https://github.com/facontidavide/PlotJuggler) to
 visualize your logs offline or in real-time.
@@ -95,7 +97,7 @@ Details in [CHANGELOG.rst](data_tamer_cpp/CHANGELOG.rst); measurements in
 int main()
 {
   // Multiple channels can use this sink. Data will be saved in mylog.mcap
-  auto mcap_sink = std::make_shared<DataTamer::MCAPSink>("mylog.mcap");
+  auto mcap_sink = DataTamer::MCAPSink::create("mylog.mcap");
 
   // Create a channel and attach a sink. A channel can have multiple sinks
   auto channel = DataTamer::LogChannel::create("my_channel");
@@ -178,7 +180,7 @@ std::string_view TypeDefinition(Point3D& point, AddField& add) {
 int main()
 {
   auto channel = DataTamer::LogChannel::create("my_channel");
-  channel->addDataSink(std::make_shared<DataTamer::MCAPSink>("mylog.mcap"));
+  channel->addDataSink(DataTamer::MCAPSink::create("mylog.mcap"));
 
   // Array/vectors are supported natively
   std::vector<double> values = {1, 2, 3, 4};

--- a/data_tamer_cpp/CHANGELOG.rst
+++ b/data_tamer_cpp/CHANGELOG.rst
@@ -4,6 +4,30 @@ Changelog for package data_tamer
 
 Unreleased
 ----------
+* **Breaking, sinks**: ``DataSinkBase`` is replaced by composition. A sink
+  implements ``DataSink`` (``onSchema(const Schema&)``, ``onSnapshot(const
+  SnapshotRef&)``; throw to report a failure) and is owned by a ``SinkWorker``,
+  which holds the queue and the delivery thread and is what
+  ``LogChannel::addDataSink`` takes. The worker is always stopped before the
+  sink is destroyed, and its destructor delivers what is still queued, so the
+  old ``stopThread()``-in-every-destructor rule and the four lifecycle calls
+  (``stopThread``, ``stopAcceptingSnapshots``, ``processQueuedSnapshots``,
+  ``startAcceptingSnapshots``) are gone; use ``SinkWorker::stop()``,
+  ``start()`` and ``drain()``. ``SinkWorker::Delivery::Manual`` runs without a
+  thread for applications that deliver from their own loop.
+  ``MCAPSink::create(path)``, ``ROS2PublisherSink::create(node, prefix)`` and
+  ``SinkWorker::create<T>(...)`` return a ready-to-attach worker;
+  ``worker->as<MCAPSink>()`` reaches the sink's own methods.
+  ``MCAPSink::finishQueueAndStop()`` is ``worker->stop()`` followed by
+  ``stopRecording()``; ``restartRecording()`` no longer reopens admission, call
+  ``worker->start()`` after a stop. A failed MCAP write now throws from the
+  callback and is reported by ``SinkWorker::errors()`` / ``lastError()``.
+* **Breaking, snapshots**: ``Snapshot`` no longer carries ``channel_name`` (the
+  schema hash identifies the channel; ``Schema::channel_name`` has the name), so
+  it is fully owning. ``SnapshotRef`` is now declared in ``data_sink.hpp`` as an
+  opaque move-only handle: keep a snapshot past the callback with
+  ``ref.clone()``; ``DataSinkBase::retainSnapshot()`` and its thread-local
+  context are gone.
 * Build: the library, tests and benchmarks compile as C++20; the installed
   headers remain C++17 (consumers need ``cxx_std_17``), enforced by a test
   target that compiles every core public header as strict C++17 and by building

--- a/data_tamer_cpp/benchmarks/data_tamer_benchmark.cpp
+++ b/data_tamer_cpp/benchmarks/data_tamer_benchmark.cpp
@@ -35,7 +35,7 @@ static void DT_Doubles(benchmark::State& state)
   std::vector<double> values(size_t(state.range(0)));
   auto registry = ChannelsRegistry();
   auto channel = registry.getChannel("channel");
-  channel->addDataSink(std::make_shared<NullSink>());
+  channel->addDataSink(NullSink::create());
   channel->registerValue("values", &values);
   measureSnapshots(state, *channel);
 }
@@ -45,7 +45,7 @@ static void DT_PoseType(benchmark::State& state)
   std::vector<TestTypes::Pose> poses(size_t(state.range(0)));
   auto registry = ChannelsRegistry();
   auto channel = registry.getChannel("channel");
-  channel->addDataSink(std::make_shared<NullSink>());
+  channel->addDataSink(NullSink::create());
   channel->registerValue("values", &poses);
   measureSnapshots(state, *channel);
 }
@@ -58,7 +58,7 @@ static void DT_MultiSink(benchmark::State& state)
   auto channel = registry.getChannel("channel");
   for(int i = 0; i < state.range(0); i++)
   {
-    channel->addDataSink(std::make_shared<NullSink>());
+    channel->addDataSink(NullSink::create());
   }
   channel->registerValue("values", &values);
   measureSnapshots(state, *channel);
@@ -69,7 +69,7 @@ static void DT_LoggedValueSet(benchmark::State& state)
 {
   auto registry = ChannelsRegistry();
   auto channel = registry.getChannel("channel");
-  channel->addDataSink(std::make_shared<NullSink>());
+  channel->addDataSink(NullSink::create());
   std::vector<std::shared_ptr<LoggedValue<double>>> values;
   for(int i = 0; i < state.range(0); i++)
   {
@@ -92,7 +92,7 @@ static void snapshotWithWriter(benchmark::State& state, bool transactions)
 {
   auto registry = ChannelsRegistry();
   auto channel = registry.getChannel("channel");
-  channel->addDataSink(std::make_shared<NullSink>());
+  channel->addDataSink(NullSink::create());
   std::vector<std::shared_ptr<LoggedValue<double>>> values;
   for(int i = 0; i < 100; i++)
   {

--- a/data_tamer_cpp/benchmarks/null_sink.hpp
+++ b/data_tamer_cpp/benchmarks/null_sink.hpp
@@ -7,12 +7,12 @@ namespace DataTamer
 
 /// Sink that accepts every snapshot and does nothing with it. Used by the
 /// benchmarks to measure the front end without any backend cost.
-class NullSink : public DataSinkBase
+class NullSink : public DataSink
 {
 public:
-  ~NullSink() override { stopThread(); }
-  void addChannel(std::string const&, Schema const&) override {}
-  bool storeSnapshot(const Snapshot&) override { return true; }
+  static std::shared_ptr<SinkWorker> create() { return SinkWorker::create<NullSink>(); }
+  void onSchema(Schema const&) override {}
+  void onSnapshot(const SnapshotRef&) override {}
 };
 
 }  // namespace DataTamer

--- a/data_tamer_cpp/benchmarks/rt_latency.cpp
+++ b/data_tamer_cpp/benchmarks/rt_latency.cpp
@@ -61,20 +61,29 @@ static Options parse(int argc, char** argv)
       const auto result = std::from_chars(value, end, dst);
       if(result.ec != std::errc{} || result.ptr != end)
       {
-        std::fprintf(stderr, "invalid option %s: expected an integer, got %s\n", argv[i - 1],
-                     value);
+        std::fprintf(stderr, "invalid option %s: expected an integer, got %s\n",
+                     argv[i - 1], value);
         std::exit(1);
       }
     };
-    if(!std::strcmp(argv[i], "--values")) nextInteger(o.values);
-    else if(!std::strcmp(argv[i], "--sinks")) nextInteger(o.sinks);
-    else if(!std::strcmp(argv[i], "--writers")) nextInteger(o.writers);
-    else if(!std::strcmp(argv[i], "--seconds")) nextInteger(o.seconds);
-    else if(!std::strcmp(argv[i], "--rate")) nextInteger(o.rate_hz);
-    else if(!std::strcmp(argv[i], "--mcap")) o.mcap = nextArgument();
-    else if(!std::strcmp(argv[i], "--fifo")) o.fifo = true;
-    else if(!std::strcmp(argv[i], "--transactions")) o.transactions = true;
-    else if(!std::strcmp(argv[i], "--vector-writer")) o.vector_writer = true;
+    if(!std::strcmp(argv[i], "--values"))
+      nextInteger(o.values);
+    else if(!std::strcmp(argv[i], "--sinks"))
+      nextInteger(o.sinks);
+    else if(!std::strcmp(argv[i], "--writers"))
+      nextInteger(o.writers);
+    else if(!std::strcmp(argv[i], "--seconds"))
+      nextInteger(o.seconds);
+    else if(!std::strcmp(argv[i], "--rate"))
+      nextInteger(o.rate_hz);
+    else if(!std::strcmp(argv[i], "--mcap"))
+      o.mcap = nextArgument();
+    else if(!std::strcmp(argv[i], "--fifo"))
+      o.fifo = true;
+    else if(!std::strcmp(argv[i], "--transactions"))
+      o.transactions = true;
+    else if(!std::strcmp(argv[i], "--vector-writer"))
+      o.vector_writer = true;
     else
     {
       std::fprintf(stderr, "unknown option %s\n", argv[i]);
@@ -83,8 +92,8 @@ static Options parse(int argc, char** argv)
   }
   if(o.values < 0 || o.sinks < 0 || o.writers < 0 || o.seconds <= 0 || o.rate_hz <= 0)
   {
-    std::fprintf(stderr,
-                 "invalid option values: counts must be nonnegative; seconds and rate must be positive\n");
+    std::fprintf(stderr, "invalid option values: counts must be nonnegative; seconds and "
+                         "rate must be positive\n");
     std::exit(1);
   }
   if(o.sinks > 8)
@@ -117,24 +126,26 @@ static void printPercentiles(std::vector<long>& ns)
 int main(int argc, char** argv)
 {
   const Options opt = parse(argc, argv);
-  std::printf("rt_latency values=%d sinks=%d writers=%d seconds=%d rate=%dHz mcap=%s fifo=%d transactions=%d vector_writer=%d\n",
+  std::printf("rt_latency values=%d sinks=%d writers=%d seconds=%d rate=%dHz mcap=%s "
+              "fifo=%d transactions=%d vector_writer=%d\n",
               opt.values, opt.sinks, opt.writers, opt.seconds, opt.rate_hz,
               opt.mcap.empty() ? "-" : opt.mcap.c_str(), int(opt.fifo),
               int(opt.transactions), int(opt.vector_writer));
 
   auto channel = LogChannel::create("rt");
-  std::vector<std::shared_ptr<DataSinkBase>> sinks;
+  std::vector<std::shared_ptr<SinkWorker>> sinks;
+  std::shared_ptr<SinkWorker> mcap;
   for(int i = 0; i < opt.sinks; i++)
   {
     if(!opt.mcap.empty() && i == 0)
     {
-      auto mcap = std::make_shared<MCAPSink>(opt.mcap, /*compression*/ true);
-      mcap->setMaxTimeBeforeReset(std::chrono::seconds(0));
+      mcap = MCAPSink::create(opt.mcap, /*compression*/ true);
+      mcap->as<MCAPSink>().setMaxTimeBeforeReset(std::chrono::seconds(0));
       sinks.push_back(mcap);
     }
     else
     {
-      sinks.push_back(std::make_shared<NullSink>());
+      sinks.push_back(NullSink::create());
     }
     channel->addDataSink(sinks.back());
   }
@@ -236,7 +247,8 @@ int main(int argc, char** argv)
     {
       failed++;
     }
-    durations.push_back(std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+    durations.push_back(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
   }
 
   run = false;
@@ -245,9 +257,11 @@ int main(int argc, char** argv)
     t.join();
   }
 
-  for(const auto& sink : sinks)
-    if(auto mcap = std::dynamic_pointer_cast<MCAPSink>(sink))
-      mcap->finishQueueAndStop();
+  if(mcap)
+  {
+    mcap->stop();
+    mcap->as<MCAPSink>().stopRecording();
+  }
 
   printPercentiles(durations);
   const auto stats = channel->stats();
@@ -255,13 +269,16 @@ int main(int argc, char** argv)
               (unsigned long long)stats.write_lock_contended,
               (unsigned long long)stats.write_lock_wait_max_ns);
   uint64_t attachment_drops = 0;
-  for(const auto& sink : sinks) attachment_drops += channel->droppedSnapshots(sink);
-  std::printf("pool_exhausted=%llu payload_reallocations=%llu dropped_oversize=%llu attachment_drops=%llu\n",
+  for(const auto& sink : sinks)
+    attachment_drops += channel->droppedSnapshots(sink);
+  std::printf("pool_exhausted=%llu payload_reallocations=%llu dropped_oversize=%llu "
+              "attachment_drops=%llu\n",
               (unsigned long long)stats.pool_exhausted,
               (unsigned long long)stats.payload_reallocations,
               (unsigned long long)stats.dropped_oversize,
               (unsigned long long)attachment_drops);
-  std::printf("allocations per call after warm-up: %.4f\n", double(allocations) / double(total));
+  std::printf("allocations per call after warm-up: %.4f\n",
+              double(allocations) / double(total));
   std::printf("allocations after warm-up: %zu\n", allocations);
   std::printf("takeSnapshot returned false: %zu / %zu\n", failed, total);
   std::printf("fifo=%d\n", int(fifo_ok));

--- a/data_tamer_cpp/benchmarks/sink_latency.cpp
+++ b/data_tamer_cpp/benchmarks/sink_latency.cpp
@@ -30,27 +30,20 @@ std::chrono::nanoseconds steadyNow()
       std::chrono::steady_clock::now().time_since_epoch());
 }
 
-class LatencySink : public DataSinkBase
+class LatencySink : public DataSink
 {
 public:
   LatencySink() { latencies_.reserve(kSnapshots); }
-  ~LatencySink() override { finish(); }
 
-  void addChannel(const std::string&, const Schema&) override {}
+  void onSchema(const Schema&) override {}
 
-  void finish()
-  {
-    stopThread();
-    processQueuedSnapshots();
-  }
-
+  /// Valid once the owning SinkWorker has been stopped.
   std::vector<int64_t>& latencies() { return latencies_; }
 
 protected:
-  bool storeSnapshot(const Snapshot& snapshot) override
+  void onSnapshot(const SnapshotRef& snapshot) override
   {
-    latencies_.push_back((steadyNow() - snapshot.timestamp).count());
-    return true;
+    latencies_.push_back((steadyNow() - snapshot->timestamp).count());
   }
 
 private:
@@ -115,7 +108,7 @@ bool readCpuTicks(uint64_t& ticks)
 
 int measureIdle()
 {
-  auto sink = std::make_shared<LatencySink>();
+  auto sink = SinkWorker::create<LatencySink>();
 #ifdef __linux__
   uint64_t before = 0;
   uint64_t after = 0;
@@ -134,7 +127,7 @@ int measureIdle()
     std::fprintf(stderr, "failed to read process CPU ticks\n");
     return 1;
   }
-  sink->finish();
+  sink->stop();
 
   const double elapsed = std::chrono::duration<double>(end - start).count();
   const uint64_t ticks = after - before;
@@ -144,7 +137,7 @@ int measureIdle()
               static_cast<unsigned long long>(ticks), ticks_per_second, elapsed,
               cpu_percent);
 #else
-  sink->finish();
+  sink->stop();
   std::printf("idle CPU measurement unavailable on this platform\n");
 #endif
   return 0;
@@ -153,7 +146,7 @@ int measureIdle()
 int measureDelivery()
 {
   auto channel = LogChannel::create("sink_latency");
-  auto sink = std::make_shared<LatencySink>();
+  auto sink = SinkWorker::create<LatencySink>();
   channel->addDataSink(sink);
   uint64_t value = 0;
   channel->registerValue("value", &value);
@@ -176,10 +169,10 @@ int measureDelivery()
     }
   }
 
-  sink->finish();
+  sink->stop();
   std::printf("sink_latency snapshots=%zu rate_hz=1000\n", kSnapshots);
   std::printf("submissions successful=%zu failed=%zu\n", successful, failed);
-  printLatencies(sink->latencies());
+  printLatencies(sink->as<LatencySink>().latencies());
   return 0;
 }
 }  // namespace

--- a/data_tamer_cpp/examples/T01_basic_example.cpp
+++ b/data_tamer_cpp/examples/T01_basic_example.cpp
@@ -8,7 +8,7 @@ int main()
 
   // start defining one or more Sinks that must be added by default.
   // Do addDefaultSink BEFORE creating a channel.
-  auto dummy_sink = std::make_shared<DummySink>();
+  auto dummy_sink = DummySink::create();
   ChannelsRegistry::Global().addDefaultSink(dummy_sink);
 
   // Create (or get) a channel using the global registry (singleton)

--- a/data_tamer_cpp/examples/T02_custom_types.cpp
+++ b/data_tamer_cpp/examples/T02_custom_types.cpp
@@ -21,7 +21,7 @@ int main()
   using namespace TestTypes;
   using namespace DataTamer;
 
-  auto dummy_sink = std::make_shared<DummySink>();
+  auto dummy_sink = DummySink::create();
   ChannelsRegistry::Global().addDefaultSink(dummy_sink);
   auto channel = ChannelsRegistry::Global().getChannel("my_channel");
 
@@ -50,6 +50,6 @@ int main()
   channel->takeSnapshot();
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
-  std::cout << "\nMessage size: " << dummy_sink->latestPayloadSize()
+  std::cout << "\nMessage size: " << dummy_sink->as<DummySink>().latestPayloadSize()
             << " expected: " << expected_size << std::endl;
 }

--- a/data_tamer_cpp/examples/T03_mcap_writer.cpp
+++ b/data_tamer_cpp/examples/T03_mcap_writer.cpp
@@ -8,7 +8,7 @@ using namespace DataTamer;
 
 int main()
 {
-  auto mcap_sink = std::make_shared<MCAPSink>("test_sample.mcap");
+  auto mcap_sink = MCAPSink::create("test_sample.mcap");
   ChannelsRegistry::Global().addDefaultSink(mcap_sink);
 
   // Create (or get) a channel using the global registry (singleton)

--- a/data_tamer_cpp/examples/mcap_1m_per_sec.cpp
+++ b/data_tamer_cpp/examples/mcap_1m_per_sec.cpp
@@ -72,7 +72,7 @@ int main()
 {
   // Start defining one or more Sinks that must be added by default.
   // Do this BEFORE creating a channel.
-  auto mcap_sink = std::make_shared<MCAPSink>("test_1M.mcap");
+  auto mcap_sink = MCAPSink::create("test_1M.mcap");
   ChannelsRegistry::Global().addDefaultSink(mcap_sink);
 
   // Create (or get) a channel using the global registry (singleton)

--- a/data_tamer_cpp/examples/ros2_publisher.cpp
+++ b/data_tamer_cpp/examples/ros2_publisher.cpp
@@ -10,7 +10,7 @@ int main(int argc, char* argv[])
   rclcpp::init(argc, argv);
   auto node = std::make_shared<rclcpp::Node>("test_datatamer");
 
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(node, "test");
+  auto ros2_sink = ROS2PublisherSink::create(node, "test");
   ChannelsRegistry::Global().addDefaultSink(ros2_sink);
 
   // Create (or get) a channel using the global registry (singleton)

--- a/data_tamer_cpp/include/data_tamer/channel.hpp
+++ b/data_tamer_cpp/include/data_tamer/channel.hpp
@@ -21,7 +21,7 @@ inline std::chrono::nanoseconds NsecSinceEpoch()
   return std::chrono::duration_cast<std::chrono::nanoseconds>(since_epoch);
 }
 
-class DataSinkBase;
+class SinkWorker;
 class LogChannel;
 class ChannelsRegistry;
 
@@ -160,16 +160,17 @@ public:
   void unregister(const RegistrationID& id);
 
   /**
-   * @brief addDataSink add a sink, i.e. a class collecting our snapshots.
+   * @brief addDataSink attaches a sink (a SinkWorker owning a DataSink, see
+   * MCAPSink::create or SinkWorker::create<T>) that will receive our snapshots.
    * A channel holds at most eight sinks; adding a ninth throws. Adding the
    * same sink twice is a no-op.
    */
-  void addDataSink(std::shared_ptr<DataSinkBase> sink);
+  void addDataSink(std::shared_ptr<SinkWorker> sink);
 
   /**
    * @brief removeDataSink remove a sink, i.e. a class collecting our snapshots.
    */
-  void removeDataSink(std::shared_ptr<DataSinkBase> sink);
+  void removeDataSink(std::shared_ptr<SinkWorker> sink);
 
   /**
   * @brief getNumberOfSinks returns the number of registered sinks.
@@ -246,8 +247,7 @@ public:
   [[nodiscard]] uint64_t droppedOversize() const;
 
   /// Failed publications to this attachment; zero if sink is not attached.
-  [[nodiscard]] uint64_t
-  droppedSnapshots(const std::shared_ptr<DataSinkBase>& sink) const;
+  [[nodiscard]] uint64_t droppedSnapshots(const std::shared_ptr<SinkWorker>& sink) const;
 
   struct Stats
   {

--- a/data_tamer_cpp/include/data_tamer/data_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/data_sink.hpp
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <string_view>
+#include <typeinfo>
 #include <vector>
 
 namespace moodycamel
@@ -16,8 +16,11 @@ struct ProducerToken;
 
 namespace DataTamer
 {
-class SnapshotRef;
+
 class LogChannel;
+class SinkWorker;
+class SnapshotPool;
+struct PoolSlot;
 
 using ActiveMask = std::vector<uint8_t>;
 using PayloadVector = std::vector<uint8_t>;
@@ -25,104 +28,146 @@ using PayloadVector = std::vector<uint8_t>;
 bool GetBit(const ActiveMask& mask, size_t index);
 void SetBit(ActiveMask& mask, size_t index, bool val);
 
+/// One captured sample of a channel. Fully owning: a copy is an independent record.
+/// The channel is identified by schema_hash (the hash covers the channel name).
 struct Snapshot
 {
-  std::string_view channel_name;
-
   /// Unique identifier of the schema
   uint64_t schema_hash;
-
   /// snapshot timestamp
   std::chrono::nanoseconds timestamp;
-
   /// Vector that tell us if a field of the schema is
   /// active or not. It is basically an optimized vector
   /// of bools, where each byte contains 8 boolean flags.
   ActiveMask active_mask;
-
   /// serialized dat containing all the values, ordered as in the schema
   PayloadVector payload;
 };
 
 /**
- * @brief The DataSnapshot contains all the information passed by
- * LogChannel::takeSnapshot to a DataSink.
- *
- * Note: The vector contains:
- *
- * - The serialized SnapshotHeader in the first bytes
- * - The payload in the following bytes
+ * @brief Move-only handle to a pooled Snapshot. Holds one reference on the
+ * pool slot, so a sink may keep it for as long as it likes: the slot is not
+ * reused until the last handle is destroyed, even if the channel is gone.
+ * clone() adds a reference without copying the data; `Snapshot copy = *ref;`
+ * makes an independent copy.
  */
-using DataSnapshot = std::vector<uint8_t>;
+class SnapshotRef
+{
+public:
+  SnapshotRef() = default;
+  /// Takes ownership of one already-counted reference on `slot` (library internal).
+  SnapshotRef(std::shared_ptr<SnapshotPool> pool, PoolSlot* slot);
+  SnapshotRef(SnapshotRef&& other) noexcept;
+  SnapshotRef& operator=(SnapshotRef&& other) noexcept;
+  SnapshotRef(const SnapshotRef&) = delete;
+  SnapshotRef& operator=(const SnapshotRef&) = delete;
+  ~SnapshotRef();
+
+  /// Explicit share: adds a reference to the same slot.
+  [[nodiscard]] SnapshotRef clone() const;
+  void reset();
+
+  const Snapshot& operator*() const;
+  const Snapshot* operator->() const;
+  explicit operator bool() const { return slot_ != nullptr; }
+
+private:
+  std::shared_ptr<SnapshotPool> pool_;
+  PoolSlot* slot_ = nullptr;
+};
 
 /**
- * @brief The DataSinkBase is the base class to use to create
- * your own DataSink
+ * @brief Interface implemented by a sink. The two callbacks are invoked only by
+ * the SinkWorker that owns the sink and are serialized with each other, so a
+ * sink needs no lock of its own for the state they touch:
+ *
+ * - onSchema() runs on the thread that attaches the channel to the sink
+ *   (addDataSink or the first takeSnapshot), once per channel schema.
+ * - onSnapshot() runs on the worker thread, in queue order. Throw to report a
+ *   failure: the worker counts it and keeps the message (see SinkWorker).
+ *
+ * Never call LogChannel control methods from a callback.
  */
-class DataSinkBase
+class DataSink
+{
+public:
+  virtual ~DataSink() = default;
+
+protected:
+  friend class SinkWorker;
+  virtual void onSchema(const Schema& schema) = 0;
+  virtual void onSnapshot(const SnapshotRef& snapshot) = 0;
+};
+
+/**
+ * @brief Owns a DataSink, the queue that channels publish into and the thread
+ * that delivers queued snapshots to the sink. It is what LogChannel::addDataSink
+ * takes. The worker is stopped before the sink is destroyed, so a sink never
+ * receives a callback while it is being torn down.
+ */
+class SinkWorker
 {
 public:
   static constexpr size_t kDefaultQueueCapacity = 1024;
 
-  /// Preallocated, block-rounded queue capacity, shared by all producers.
-  explicit DataSinkBase(size_t queue_capacity = kDefaultQueueCapacity);
+  enum class Delivery : uint8_t
+  {
+    /// A worker thread delivers queued snapshots as they arrive (default).
+    Threaded,
+    /// No thread: the application delivers by calling drain() itself.
+    Manual
+  };
 
-  DataSinkBase(const DataSinkBase& other) = delete;
-  DataSinkBase& operator=(const DataSinkBase& other) = delete;
+  /// `queue_capacity` is preallocated (block-rounded) and shared by all producers.
+  explicit SinkWorker(std::unique_ptr<DataSink> sink,
+                      size_t queue_capacity = kDefaultQueueCapacity,
+                      Delivery delivery = Delivery::Threaded);
+  ~SinkWorker();
+  SinkWorker(const SinkWorker&) = delete;
+  SinkWorker& operator=(const SinkWorker&) = delete;
 
-  DataSinkBase(DataSinkBase&& other) = delete;
-  DataSinkBase& operator=(DataSinkBase&& other) = delete;
+  /// Build a sink of type T and wrap it: SinkWorker::create<MCAPSink>("out.mcap").
+  template <typename T, typename... Args>
+  static std::shared_ptr<SinkWorker> create(Args&&... args)
+  {
+    return std::make_shared<SinkWorker>(std::make_unique<T>(std::forward<Args>(args)...));
+  }
 
-  virtual ~DataSinkBase();
+  /// Stop accepting snapshots, wait for the callback in progress, join the
+  /// worker thread and deliver everything still queued. Idempotent. Never call
+  /// it from a callback.
+  void stop();
+  /// Resume after stop(): reopen admission and restart the worker thread.
+  void start();
+  /// Deliver every snapshot queued so far on the calling thread. Returns after
+  /// a callback in progress on the worker has finished, so everything taken
+  /// before the call has been delivered when it returns.
+  void drain();
 
-  /**
-   * @brief addChannel will register a schema into the sink.
-   * That schema will be recognized by its hash.
-   *
-   * @param name    name of the channel
-   * @param schema  a schema, suaully obtained from LogChannel::getSchema()
-   */
-  virtual void addChannel(const std::string& name, const Schema& schema) = 0;
+  DataSink& sink() { return *_sink; }
+  const DataSink& sink() const { return *_sink; }
+  /// Typed access to the owned sink, e.g. worker.as<MCAPSink>().restartRecording(...).
+  /// Throws std::bad_cast if the sink is not a T.
+  template <typename T>
+  T& as()
+  {
+    return dynamic_cast<T&>(*_sink);
+  }
 
-  /// Number of exceptions thrown by queue-dispatched storeSnapshot callbacks.
-  [[nodiscard]] uint64_t storeErrors() const;
-
-protected:
-  /**
-   * @brief storeSnapshot contains the code to execute when popping a snapshot from
-   * the queue.
-   *
-   * @param snapshot data to be pushed into the sink.
-   * @return true if processed successfully
-   */
-  virtual bool storeSnapshot(const Snapshot& snapshot) = 0;
-
-  /// Derived destructors must stop the worker before destroying callback state.
-  /// Control methods must be externally serialized, never called in callbacks.
-  void stopThread();
-
-  /// Close producer admission and wait for admitted enqueues to complete.
-  void stopAcceptingSnapshots();
-
-  /// Serialize dequeue and callbacks with the worker; drain accepted work.
-  void processQueuedSnapshots();
-
-  void startAcceptingSnapshots();
-
-  /// Callback-only clone of the currently delivered pool reference. Include
-  /// details/snapshot_pool.hpp to use the returned handle. Direct calls to a
-  /// derived storeSnapshot method cannot retain queue ownership.
-  /// The handle reaches the callback through thread-local context rather than a
-  /// parameter so that the storeSnapshot(const Snapshot&) signature of existing
-  /// sinks stays source compatible.
-  [[nodiscard]] SnapshotRef retainSnapshot() const;
+  /// Number of onSnapshot() calls that threw, and the message of the last one.
+  [[nodiscard]] uint64_t errors() const;
+  [[nodiscard]] std::string lastError() const;
 
 private:
   friend class LogChannel;
   std::unique_ptr<moodycamel::ProducerToken> makeProducerToken();
   bool tryPush(moodycamel::ProducerToken& token, SnapshotRef&& snapshot);
+  /// Serialized with onSnapshot(); exceptions from onSchema() propagate.
+  void addSchema(const Schema& schema);
+
   struct Pimpl;
   std::unique_ptr<Pimpl> _p;
+  std::unique_ptr<DataSink> _sink;
 };
 
 //--------------------------------------------------

--- a/data_tamer_cpp/include/data_tamer/data_tamer.hpp
+++ b/data_tamer_cpp/include/data_tamer/data_tamer.hpp
@@ -18,7 +18,7 @@ public:
 
   /// Once added here, this sink will be automatically connected to
   /// any new channel created with getChannel()
-  void addDefaultSink(std::shared_ptr<DataSinkBase> sink);
+  void addDefaultSink(std::shared_ptr<SinkWorker> sink);
 
   /// Create a new channel or get a previously create one.
   [[nodiscard]] std::shared_ptr<LogChannel> getChannel(std::string const& channel_name);

--- a/data_tamer_cpp/include/data_tamer/details/snapshot_pool.hpp
+++ b/data_tamer_cpp/include/data_tamer/details/snapshot_pool.hpp
@@ -32,13 +32,11 @@ class SnapshotPool
 public:
   static constexpr size_t kDefaultCapacity = 64;
 
-  SnapshotPool(size_t capacity, size_t payload_capacity, size_t mask_bytes,
-               std::string channel_name = {})
-    : capacity_(capacity), channel_name_(std::move(channel_name)), slots_(new PoolSlot[capacity])
+  SnapshotPool(size_t capacity, size_t payload_capacity, size_t mask_bytes)
+    : capacity_(capacity), slots_(new PoolSlot[capacity])
   {
     for(size_t i = 0; i < capacity_; i++)
     {
-      slots_[i].snapshot.channel_name = channel_name_;
       slots_[i].snapshot.payload.reserve(payload_capacity);
       slots_[i].snapshot.active_mask.resize(mask_bytes);
     }
@@ -73,9 +71,15 @@ public:
     return nullptr;
   }
 
-  static void addRef(PoolSlot* slot) { slot->refs.fetch_add(1, std::memory_order_relaxed); }
+  static void addRef(PoolSlot* slot)
+  {
+    slot->refs.fetch_add(1, std::memory_order_relaxed);
+  }
 
-  static void release(PoolSlot* slot) { slot->refs.fetch_sub(1, std::memory_order_release); }
+  static void release(PoolSlot* slot)
+  {
+    slot->refs.fetch_sub(1, std::memory_order_release);
+  }
 
   size_t capacity() const { return capacity_; }
 
@@ -97,78 +101,9 @@ public:
 
 private:
   const size_t capacity_;
-  const std::string channel_name_;
   std::unique_ptr<PoolSlot[]> slots_;
   size_t scan_from_ = 0;  // snapshot thread only
   std::atomic<uint64_t> exhausted_{ 0 };
-};
-
-/**
- * @brief Move-only handle to a PoolSlot. Holds one reference on the slot and a
- * shared_ptr to the pool, so a sink may keep it for as long as it likes: the
- * slot is simply not reused until the last handle is destroyed, and the pool
- * outlives the channel if necessary.
- */
-class SnapshotRef
-{
-public:
-  SnapshotRef() = default;
-
-  /// Takes ownership of one already-counted reference on `slot`.
-  SnapshotRef(std::shared_ptr<SnapshotPool> pool, PoolSlot* slot)
-    : pool_(std::move(pool)), slot_(slot)
-  {}
-
-  SnapshotRef(SnapshotRef&& other) noexcept
-    : pool_(std::move(other.pool_)), slot_(other.slot_)
-  {
-    other.slot_ = nullptr;
-  }
-
-  SnapshotRef& operator=(SnapshotRef&& other) noexcept
-  {
-    if(this != &other)
-    {
-      reset();
-      pool_ = std::move(other.pool_);
-      slot_ = other.slot_;
-      other.slot_ = nullptr;
-    }
-    return *this;
-  }
-
-  SnapshotRef(const SnapshotRef&) = delete;
-  SnapshotRef& operator=(const SnapshotRef&) = delete;
-
-  ~SnapshotRef() { reset(); }
-
-  /// Explicit copy: adds a reference.
-  SnapshotRef clone() const
-  {
-    if(slot_)
-    {
-      SnapshotPool::addRef(slot_);
-    }
-    return SnapshotRef(pool_, slot_);
-  }
-
-  void reset()
-  {
-    if(slot_)
-    {
-      SnapshotPool::release(slot_);
-      slot_ = nullptr;
-    }
-    pool_.reset();
-  }
-
-  const Snapshot& operator*() const { return slot_->snapshot; }
-  const Snapshot* operator->() const { return &slot_->snapshot; }
-  explicit operator bool() const { return slot_ != nullptr; }
-
-private:
-  std::shared_ptr<SnapshotPool> pool_;
-  PoolSlot* slot_ = nullptr;
 };
 
 }  // namespace DataTamer

--- a/data_tamer_cpp/include/data_tamer/sinks/dummy_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/dummy_sink.hpp
@@ -13,41 +13,15 @@ namespace DataTamer
  * Used mostly for testing and debugging.
  *
  * All accessors take the internal mutex, so they may be called from any thread
- * while the sink thread is delivering snapshots.
+ * while the worker is delivering snapshots. Use SinkWorker::drain() instead of
+ * sleeping to observe every snapshot taken so far.
  */
-class DummySink : public DataSinkBase
+class DummySink : public DataSink
 {
 public:
-  explicit DummySink(size_t queue_capacity = kDefaultQueueCapacity)
-    : DataSinkBase(queue_capacity)
-  {}
+  static std::shared_ptr<SinkWorker> create() { return SinkWorker::create<DummySink>(); }
 
-  ~DummySink() override { stopThread(); }
-
-  /// Deliver every snapshot already pushed by takeSnapshot(), including one the
-  /// worker is currently storing. Tests call this instead of sleeping.
-  void flush() { processQueuedSnapshots(); }
-
-  void addChannel(std::string const& /*name*/, Schema const& schema) override
-  {
-    std::scoped_lock lk(mutex_);
-    schemas_[schema.hash] = schema;
-    snapshots_count_[schema.hash] = 0;
-  }
-
-  bool storeSnapshot(const Snapshot& snapshot) override
-  {
-    std::scoped_lock lk(mutex_);
-    latest_snapshot_ = snapshot;
-    auto it = snapshots_count_.find(snapshot.schema_hash);
-    if(it != snapshots_count_.end())
-    {
-      it->second++;
-    }
-    return true;
-  }
-
-  /// Copy of the most recent snapshot delivered to storeSnapshot().
+  /// Copy of the most recent snapshot delivered to onSnapshot().
   Snapshot latestSnapshot() const
   {
     std::scoped_lock lk(mutex_);
@@ -93,6 +67,25 @@ public:
   {
     std::scoped_lock lk(mutex_);
     return schemas_.at(hash);
+  }
+
+protected:
+  void onSchema(Schema const& schema) override
+  {
+    std::scoped_lock lk(mutex_);
+    schemas_[schema.hash] = schema;
+    snapshots_count_[schema.hash] = 0;
+  }
+
+  void onSnapshot(const SnapshotRef& snapshot) override
+  {
+    std::scoped_lock lk(mutex_);
+    latest_snapshot_ = *snapshot;
+    auto it = snapshots_count_.find(snapshot->schema_hash);
+    if(it != snapshots_count_.end())
+    {
+      it->second++;
+    }
   }
 
 private:

--- a/data_tamer_cpp/include/data_tamer/sinks/mcap_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/mcap_sink.hpp
@@ -10,10 +10,12 @@ namespace DataTamer
 {
 
 /**
- * @brief The MCAPSink is an implementation of DataSinkBase that
- * will save the data as MCAP file (https://mcap.dev/)
+ * @brief The MCAPSink is a DataSink that saves the data as an MCAP file
+ * (https://mcap.dev/). Create it with MCAPSink::create() and pass the returned
+ * worker to LogChannel::addDataSink(); reach the methods below through
+ * worker->as<MCAPSink>().
  */
-class MCAPSink : public DataSinkBase
+class MCAPSink : public DataSink
 {
 public:
   /**
@@ -25,14 +27,16 @@ public:
    * @param filepath   path of the file to be saved. Should have extension ".mcap"
    * @param do_compression if true, compress the data on the fly.
    */
-  explicit MCAPSink(std::string const& filepath, bool do_compression = false,
-                    size_t queue_capacity = kDefaultQueueCapacity);
+  explicit MCAPSink(std::string const& filepath, bool do_compression = false);
+
+  /// Ready-to-attach sink: SinkWorker::create<MCAPSink>(filepath, do_compression).
+  static std::shared_ptr<SinkWorker> create(std::string const& filepath,
+                                            bool do_compression = false)
+  {
+    return SinkWorker::create<MCAPSink>(filepath, do_compression);
+  }
 
   ~MCAPSink() override;
-
-  void addChannel(std::string const& channel_name, Schema const& schema) override;
-
-  bool storeSnapshot(const Snapshot& snapshot) override;
 
   /// After a certain amount of time, the MCAP file will be reset
   /// and overwritten. Default value is 600 seconds (10 minutes)
@@ -45,12 +49,10 @@ public:
   /// and then saved instead of overwriting the previous file.
   void setCreateNewFileOnReset(bool create_new_file);
 
-  /// Stop recording and save the file
+  /// Stop recording and save the file. Snapshots delivered afterwards are
+  /// dropped until restartRecording(). To also deliver what is still queued,
+  /// call SinkWorker::stop() (or drain()) first.
   void stopRecording();
-
-  /// Stop taking snapshots, finish the existing queue, then `stopRecording`
-  /// Waits for admitted publications and callbacks before closing the file.
-  void finishQueueAndStop();
 
   /**
    * @brief restartRecording saves the current file (unless we did it already,
@@ -62,6 +64,10 @@ public:
    * WARNING: if this is called with the same filename as previously, the file counter will be reset, too.
    */
   void restartRecording(std::string const& filepath, bool do_compression = false);
+
+protected:
+  void onSchema(Schema const& schema) override;
+  void onSnapshot(const SnapshotRef& snapshot) override;
 
 private:
   struct Pimpl;

--- a/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
+++ b/data_tamer_cpp/include/data_tamer/sinks/ros2_publisher_sink.hpp
@@ -18,7 +18,10 @@ namespace DataTamer
 using PublisherNodeInterfaces =
     rclcpp::node_interfaces::NodeInterfaces<rclcpp::node_interfaces::NodeTopicsInterface>;
 
-class ROS2PublisherSink : public DataSinkBase
+/// Publishes schemas and snapshots on `<topic_prefix>/schemas` and
+/// `<topic_prefix>/data`. Create it with ROS2PublisherSink::create() and pass
+/// the returned worker to LogChannel::addDataSink().
+class ROS2PublisherSink : public DataSink
 {
 public:
   template <typename NodeT>
@@ -27,11 +30,19 @@ public:
                         ConstructorTag{})
   {}
 
+  template <typename NodeT>
+  static std::shared_ptr<SinkWorker> create(NodeT&& nodelike,
+                                            const std::string& topic_prefix)
+  {
+    return SinkWorker::create<ROS2PublisherSink>(std::forward<NodeT>(nodelike),
+                                                 topic_prefix);
+  }
+
   ~ROS2PublisherSink() override;
 
-  void addChannel(const std::string& name, const Schema& schema) override;
-
-  bool storeSnapshot(const Snapshot& snapshot) override;
+protected:
+  void onSchema(const Schema& schema) override;
+  void onSnapshot(const SnapshotRef& snapshot) override;
 
 private:
   struct Pimpl;

--- a/data_tamer_cpp/src/channel.cpp
+++ b/data_tamer_cpp/src/channel.cpp
@@ -87,7 +87,7 @@ struct LogChannel::Pimpl
   struct SinkLink
   {
     // Members are destroyed in reverse order: token must die before its sink.
-    std::shared_ptr<DataSinkBase> sink;
+    std::shared_ptr<SinkWorker> sink;
     std::unique_ptr<moodycamel::ProducerToken> token;
     std::atomic<uint64_t> dropped{ 0 };
     bool schema_registered = false;
@@ -217,7 +217,7 @@ void LogChannel::unregister(const RegistrationID& id)
     _p->series[id.first_index + i].holder.detach();
 }
 
-void LogChannel::addDataSink(std::shared_ptr<DataSinkBase> sink)
+void LogChannel::addDataSink(std::shared_ptr<SinkWorker> sink)
 {
   if(!sink)
     throw std::invalid_argument("Can't add a null sink");
@@ -237,17 +237,17 @@ void LogChannel::addDataSink(std::shared_ptr<DataSinkBase> sink)
   link->token = link->sink->makeProducerToken();
   if(_p->schema_frozen)
   {
-    link->sink->addChannel(_p->channel_name, _p->schema);
+    link->sink->addSchema(_p->schema);
     link->schema_registered = true;
   }
-  // Neither a throwing token allocation nor addChannel can publish a partial link.
+  // Neither a throwing token allocation nor onSchema can publish a partial link.
   _p->sinks[free_slot] = std::move(link);
   if(_p->logging_started)
     _p->published_sinks[free_slot].store(_p->sinks[free_slot].get(),
                                          std::memory_order_seq_cst);
 }
 
-void LogChannel::removeDataSink(std::shared_ptr<DataSinkBase> sink)
+void LogChannel::removeDataSink(std::shared_ptr<SinkWorker> sink)
 {
   std::lock_guard const lock(_p->control_mutex);
   for(size_t i = 0; i < _p->sinks.size(); ++i)
@@ -346,7 +346,7 @@ uint64_t LogChannel::droppedOversize() const
   return _p->dropped_oversize.load(std::memory_order_relaxed);
 }
 
-uint64_t LogChannel::droppedSnapshots(const std::shared_ptr<DataSinkBase>& sink) const
+uint64_t LogChannel::droppedSnapshots(const std::shared_ptr<SinkWorker>& sink) const
 {
   std::lock_guard const lock(_p->control_mutex);
   for(const auto& link : _p->sinks)
@@ -388,7 +388,7 @@ const ActiveMask& LogChannel::getActiveFlags()
 bool LogChannel::takeSnapshot(std::chrono::nanoseconds timestamp)
 {
   // First call freezes even without sinks. Failed preparation is retryable;
-  // successful addChannel calls are remembered and nothing is published early.
+  // successful onSchema calls are remembered and nothing is published early.
   if(!_p->logging_started)
   {
     std::lock_guard const lock(_p->control_mutex);
@@ -403,13 +403,13 @@ bool LogChannel::takeSnapshot(std::chrono::nanoseconds timestamp)
           { _p->payload_capacity, checkedDouble(_p->payloadSize()), size_t(256) });
       // Publish the pool only after every slot has reserved successfully.
       _p->pool = std::make_shared<SnapshotPool>(_p->pool_capacity, capacity,
-                                                _p->active_mask.size(), _p->channel_name);
+                                                _p->active_mask.size());
     }
     for(auto& link : _p->sinks)
     {
       if(link && !link->schema_registered)
       {
-        link->sink->addChannel(_p->channel_name, _p->schema);
+        link->sink->addSchema(_p->schema);
         link->schema_registered = true;
       }
     }

--- a/data_tamer_cpp/src/data_sink.cpp
+++ b/data_tamer_cpp/src/data_sink.cpp
@@ -3,8 +3,6 @@
 #include "ConcurrentQueue/blockingconcurrentqueue.h"
 
 #include <atomic>
-#include <cassert>
-#include <cstdio>
 #include <exception>
 #include <mutex>
 #include <new>
@@ -20,29 +18,128 @@ struct QueueTraits : moodycamel::ConcurrentQueueDefaultTraits
   static void free(void* pointer) { ::operator delete(pointer); }
 };
 
-// Only the queue-dispatched callback on this thread may retain current_ref.
-thread_local const DataSinkBase* callback_sink = nullptr;
 constexpr uint64_t kClosed = uint64_t{ 1 } << 63;
 }  // namespace
 
-struct DataSinkBase::Pimpl
+//---------------- SnapshotRef ----------------
+
+SnapshotRef::SnapshotRef(std::shared_ptr<SnapshotPool> pool, PoolSlot* slot)
+  : pool_(std::move(pool)), slot_(slot)
+{}
+
+SnapshotRef::SnapshotRef(SnapshotRef&& other) noexcept
+  : pool_(std::move(other.pool_)), slot_(other.slot_)
+{
+  other.slot_ = nullptr;
+}
+
+SnapshotRef& SnapshotRef::operator=(SnapshotRef&& other) noexcept
+{
+  if(this != &other)
+  {
+    reset();
+    pool_ = std::move(other.pool_);
+    slot_ = other.slot_;
+    other.slot_ = nullptr;
+  }
+  return *this;
+}
+
+SnapshotRef::~SnapshotRef()
+{
+  reset();
+}
+
+SnapshotRef SnapshotRef::clone() const
+{
+  if(slot_)
+  {
+    SnapshotPool::addRef(slot_);
+  }
+  return SnapshotRef(pool_, slot_);
+}
+
+void SnapshotRef::reset()
+{
+  if(slot_)
+  {
+    SnapshotPool::release(slot_);
+    slot_ = nullptr;
+  }
+  pool_.reset();
+}
+
+const Snapshot& SnapshotRef::operator*() const
+{
+  return slot_->snapshot;
+}
+
+const Snapshot* SnapshotRef::operator->() const
+{
+  return &slot_->snapshot;
+}
+
+//---------------- SinkWorker ----------------
+
+struct SinkWorker::Pimpl
 {
   explicit Pimpl(size_t capacity) : queue(capacity) {}
 
-  void deliver(DataSinkBase* self)
+  // Caller holds store_mutex.
+  void deliver(DataSink& sink)
   {
-    const auto previous = callback_sink;
-    callback_sink = self;
     try
     {
-      self->storeSnapshot(*current_ref);
+      sink.onSnapshot(current_ref);
+    }
+    catch(const std::exception& e)
+    {
+      recordError(e.what());
     }
     catch(...)
     {
-      store_errors.fetch_add(1, std::memory_order_relaxed);
+      recordError("unknown exception");
     }
-    callback_sink = previous;
     current_ref.reset();
+  }
+
+  void recordError(const char* what)
+  {
+    errors.fetch_add(1, std::memory_order_relaxed);
+    std::lock_guard lock(error_mutex);
+    last_error = what;
+  }
+
+  void startThread(DataSink& sink)
+  {
+    thread = std::jthread([this, &sink](std::stop_token stop) {
+      while(!stop.stop_requested())
+      {
+        std::unique_lock handoff(handoff_mutex);
+        std::unique_lock lock(store_mutex);
+        handoff.unlock();
+        if(stop.stop_requested())
+          break;
+        if(queue.wait_dequeue_timed(current_ref, std::chrono::milliseconds(50)))
+        {
+          // Drain everything already queued under the mutex we hold; one
+          // lock round-trip per wake-up instead of one per snapshot.
+          do
+          {
+            deliver(sink);
+          } while(queue.try_dequeue(current_ref));
+        }
+      }
+    });
+  }
+
+  void joinThread()
+  {
+    if(thread.joinable())
+    {
+      thread.request_stop();
+      thread.join();
+    }
   }
 
   moodycamel::BlockingConcurrentQueue<SnapshotRef, QueueTraits> queue;
@@ -52,49 +149,32 @@ struct DataSinkBase::Pimpl
   std::mutex store_mutex;
   SnapshotRef current_ref;
   std::atomic<uint64_t> admission{ 0 };
-  std::atomic<uint64_t> store_errors{ 0 };
+  std::atomic<uint64_t> errors{ 0 };
+  std::mutex error_mutex;
+  std::string last_error;
   std::jthread thread;  // its stop token replaces a run flag
+  Delivery delivery = Delivery::Threaded;
 };
 
-DataSinkBase::DataSinkBase(size_t queue_capacity) : _p(new Pimpl(queue_capacity))
+SinkWorker::SinkWorker(std::unique_ptr<DataSink> sink, size_t queue_capacity,
+                       Delivery delivery)
+  : _p(new Pimpl(queue_capacity)), _sink(std::move(sink))
 {
-  // _p and all its members must exist before the worker can observe them.
-  _p->thread = std::jthread([this](std::stop_token stop) {
-    while(!stop.stop_requested())
-    {
-      std::unique_lock handoff(_p->handoff_mutex);
-      std::unique_lock lock(_p->store_mutex);
-      handoff.unlock();
-      if(stop.stop_requested())
-        break;
-      if(_p->queue.wait_dequeue_timed(_p->current_ref, std::chrono::milliseconds(50)))
-      {
-        // Drain everything already queued under the mutex we hold; one
-        // lock round-trip per wake-up instead of one per snapshot.
-        do
-        {
-          _p->deliver(this);
-        } while(_p->queue.try_dequeue(_p->current_ref));
-      }
-    }
-  });
-}
-
-DataSinkBase::~DataSinkBase()
-{
-  if(_p->thread.joinable())
+  if(!_sink)
+    throw std::invalid_argument("SinkWorker: null sink");
+  _p->delivery = delivery;
+  if(delivery == Delivery::Threaded)
   {
-    // Construction unwinding must preserve the original exception.
-    if(std::uncaught_exceptions() == 0)
-    {
-      std::fputs("DataSinkBase: derived destructor must call stopThread()\n", stderr);
-      assert(false && "derived destructor must call stopThread()");
-    }
-    stopThread();
+    _p->startThread(*_sink);
   }
 }
 
-std::unique_ptr<moodycamel::ProducerToken> DataSinkBase::makeProducerToken()
+SinkWorker::~SinkWorker()
+{
+  stop();
+}
+
+std::unique_ptr<moodycamel::ProducerToken> SinkWorker::makeProducerToken()
 {
   auto token = std::make_unique<moodycamel::ProducerToken>(_p->queue);
   if(!token->valid())
@@ -102,17 +182,17 @@ std::unique_ptr<moodycamel::ProducerToken> DataSinkBase::makeProducerToken()
   return token;
 }
 
-bool DataSinkBase::tryPush(moodycamel::ProducerToken& token, SnapshotRef&& snapshot)
+bool SinkWorker::tryPush(moodycamel::ProducerToken& token, SnapshotRef&& snapshot)
 {
   // Announce first, check second: a transient increment on a closed sink is
-  // withdrawn at once, and stopAcceptingSnapshots() waits for it like any other.
+  // withdrawn at once, and stop() waits for it like any other.
   struct AdmissionGuard
   {
     std::atomic<uint64_t>& admission;
     ~AdmissionGuard()
     {
       admission.fetch_sub(1, std::memory_order_release);
-      admission.notify_all();  // cheap when nobody waits; wakes stopAcceptingSnapshots()
+      admission.notify_all();  // cheap when nobody waits; wakes stop()
     }
   } guard{ _p->admission };
   if(_p->admission.fetch_add(1, std::memory_order_acq_rel) & kClosed)
@@ -121,7 +201,14 @@ bool DataSinkBase::tryPush(moodycamel::ProducerToken& token, SnapshotRef&& snaps
   return _p->queue.try_enqueue(token, std::move(snapshot));
 }
 
-void DataSinkBase::stopAcceptingSnapshots()
+void SinkWorker::addSchema(const Schema& schema)
+{
+  std::lock_guard handoff(_p->handoff_mutex);
+  std::lock_guard lock(_p->store_mutex);
+  _sink->onSchema(schema);
+}
+
+void SinkWorker::stop()
 {
   _p->admission.fetch_or(kClosed, std::memory_order_acq_rel);
   // Wait until every admitted enqueue has finished: block on the counter instead
@@ -131,44 +218,38 @@ void DataSinkBase::stopAcceptingSnapshots()
   {
     _p->admission.wait(state, std::memory_order_acquire);
   }
+  _p->joinThread();
+  drain();
 }
 
-void DataSinkBase::startAcceptingSnapshots()
+void SinkWorker::start()
 {
+  if(_p->delivery == Delivery::Threaded && !_p->thread.joinable())
+  {
+    _p->startThread(*_sink);
+  }
   _p->admission.fetch_and(~kClosed, std::memory_order_release);
 }
 
-void DataSinkBase::processQueuedSnapshots()
+void SinkWorker::drain()
 {
   std::lock_guard handoff(_p->handoff_mutex);
   std::lock_guard lock(_p->store_mutex);
   while(_p->queue.try_dequeue(_p->current_ref))
   {
-    _p->deliver(this);
+    _p->deliver(*_sink);
   }
 }
 
-void DataSinkBase::stopThread()
+uint64_t SinkWorker::errors() const
 {
-  if(_p->thread.joinable())
-  {
-    _p->thread.request_stop();
-    _p->thread.join();
-  }
+  return _p->errors.load(std::memory_order_relaxed);
 }
 
-uint64_t DataSinkBase::storeErrors() const
+std::string SinkWorker::lastError() const
 {
-  return _p->store_errors.load(std::memory_order_relaxed);
-}
-
-SnapshotRef DataSinkBase::retainSnapshot() const
-{
-  assert(callback_sink == this && "retainSnapshot is only valid inside a queued "
-                                  "callback");
-  if(callback_sink != this)
-    return {};
-  return _p->current_ref.clone();
+  std::lock_guard lock(_p->error_mutex);
+  return _p->last_error;
 }
 
 }  // namespace DataTamer

--- a/data_tamer_cpp/src/data_tamer.cpp
+++ b/data_tamer_cpp/src/data_tamer.cpp
@@ -11,7 +11,7 @@ namespace DataTamer
 struct ChannelsRegistry::Pimpl
 {
   std::unordered_map<std::string, std::shared_ptr<LogChannel>> channels;
-  std::unordered_set<std::shared_ptr<DataSinkBase>> default_sinks;
+  std::unordered_set<std::shared_ptr<SinkWorker>> default_sinks;
   Mutex mutex;
 };
 
@@ -25,7 +25,7 @@ ChannelsRegistry& ChannelsRegistry::Global()
   return obj;
 }
 
-void ChannelsRegistry::addDefaultSink(std::shared_ptr<DataSinkBase> sink)
+void ChannelsRegistry::addDefaultSink(std::shared_ptr<SinkWorker> sink)
 {
   if(!sink)
     throw std::invalid_argument("addDefaultSink: null sink");

--- a/data_tamer_cpp/src/sinks/mcap_sink.cpp
+++ b/data_tamer_cpp/src/sinks/mcap_sink.cpp
@@ -43,7 +43,7 @@ struct MCAPSink::Pimpl
   std::unique_ptr<mcap::McapWriter> writer;
 
   std::unordered_map<uint64_t, uint16_t> hash_to_channel_id;
-  std::unordered_map<std::string, Schema> schemas;
+  std::unordered_map<uint64_t, Schema> schemas;
 
   bool create_file_on_reset = false;
   std::string original_filepath;
@@ -57,9 +57,8 @@ struct MCAPSink::Pimpl
   std::recursive_mutex mutex;
 };
 
-MCAPSink::MCAPSink(const std::string& filepath, bool do_compression,
-                   size_t queue_capacity)
-  : DataSinkBase(queue_capacity), _p(std::make_unique<Pimpl>())
+MCAPSink::MCAPSink(const std::string& filepath, bool do_compression)
+  : _p(std::make_unique<Pimpl>())
 {
   _p->filepath = filepath;
   _p->compression = do_compression;
@@ -85,16 +84,13 @@ void DataTamer::MCAPSink::openFile(std::string const& filepath)
   _p->hash_to_channel_id.clear();
 }
 
-MCAPSink::~MCAPSink()
-{
-  stopThread();
-  std::scoped_lock lk(_p->mutex);
-}
+MCAPSink::~MCAPSink() = default;
 
-void MCAPSink::addChannel(std::string const& channel_name, Schema const& schema)
+void MCAPSink::onSchema(Schema const& schema)
 {
   std::scoped_lock lk(_p->mutex);
-  _p->schemas[channel_name] = schema;
+  _p->schemas[schema.hash] = schema;
+  const auto& channel_name = schema.channel_name;
   auto it = _p->hash_to_channel_id.find(schema.hash);
   if(it != _p->hash_to_channel_id.end() || !_p->writer)  // stopped: re-added on restart
   {
@@ -117,13 +113,14 @@ void MCAPSink::addChannel(std::string const& channel_name, Schema const& schema)
   _p->hash_to_channel_id[schema.hash] = publisher.id;
 }
 
-bool MCAPSink::storeSnapshot(const Snapshot& snapshot)
+void MCAPSink::onSnapshot(const SnapshotRef& ref)
 {
   std::scoped_lock lk(_p->mutex);
   if(_p->forced_stop_recording)
   {
-    return false;
+    return;
   }
+  const Snapshot& snapshot = *ref;
   // the payload must contain both the ActiveMask and the other data
   auto& merged_payload = _p->merged_payload;
   const auto size_mask = snapshot.active_mask.size();
@@ -143,7 +140,11 @@ bool MCAPSink::storeSnapshot(const Snapshot& snapshot)
   msg.publishTime = msg.logTime;
   msg.data = reinterpret_cast<std::byte const*>(merged_payload.data());  // NOLINT
   msg.dataSize = merged_payload.size();
-  const bool written = _p->writer->write(msg).ok();
+  const auto status = _p->writer->write(msg);
+  if(!status.ok())
+  {
+    throw std::runtime_error("MCAP write failed: " + status.message);
+  }
 
   // If reset_time is exceeded, we want to overwrite the current file.
   // Better than filling the disk, if you forgot to stop the application.
@@ -158,12 +159,11 @@ bool MCAPSink::storeSnapshot(const Snapshot& snapshot)
     }
     restartRecordingImpl(_p->filepath, _p->compression, false);
   }
-  return written;
 }
 
 void MCAPSink::setMaxTimeBeforeReset(std::chrono::seconds reset_time)
 {
-  std::scoped_lock lk(_p->mutex);  // read by the worker in storeSnapshot
+  std::scoped_lock lk(_p->mutex);  // read by the worker in onSnapshot
   _p->reset_time = reset_time;
 }
 
@@ -177,23 +177,11 @@ void MCAPSink::stopRecording()
 {
   std::scoped_lock lk(_p->mutex);
   _p->forced_stop_recording = true;
-  if(_p->writer)  // idempotent: finishQueueAndStop() may follow stopRecording()
+  if(_p->writer)  // idempotent
   {
     _p->writer->close();
     _p->writer.reset();
   }
-}
-
-void MCAPSink::finishQueueAndStop()
-{
-  // stop accepting new snapshots
-  stopAcceptingSnapshots();
-
-  // finish any that are queued
-  processQueuedSnapshots();
-
-  // now stop the recording as normal
-  stopRecording();
 }
 
 void MCAPSink::restartRecording(const std::string& filepath, bool do_compression)
@@ -216,15 +204,14 @@ void MCAPSink::restartRecordingImpl(const std::string& filepath, bool do_compres
   openFile(_p->filepath);
 
   // rebuild the channels
-  for(auto const& [name, schema] : _p->schemas)
+  for(auto const& [hash, schema] : _p->schemas)
   {
-    addChannel(name, schema);
+    onSchema(schema);
   }
 
   if(new_file)
   {
     _p->forced_stop_recording = false;
-    startAcceptingSnapshots();
   }
 }
 

--- a/data_tamer_cpp/src/sinks/ros2_publisher_sink.cpp
+++ b/data_tamer_cpp/src/sinks/ros2_publisher_sink.cpp
@@ -2,7 +2,6 @@
 #include "data_tamer_msgs/msg/schemas.hpp"
 #include "data_tamer_msgs/msg/snapshot.hpp"
 
-#include <mutex>
 #include <sstream>
 #include <unordered_map>
 #include <utility>
@@ -16,8 +15,8 @@ struct ROS2PublisherSink::Pimpl
     : node_interface(std::move(node_interface))
   {}
 
-  std::unordered_map<std::string, Schema> schemas;
-  std::mutex schema_mutex;
+  // onSchema/onSnapshot are serialized by the SinkWorker: no lock needed.
+  std::unordered_map<uint64_t, Schema> schemas;
 
   rclcpp::Publisher<data_tamer_msgs::msg::Schemas>::SharedPtr schema_publisher;
   rclcpp::Publisher<data_tamer_msgs::msg::Snapshot>::SharedPtr data_publisher;
@@ -34,10 +33,7 @@ ROS2PublisherSink::ROS2PublisherSink(PublisherNodeInterfaces node_interface,
   create_publishers(topic_prefix);
 }
 
-ROS2PublisherSink::~ROS2PublisherSink()
-{
-  stopThread();
-}
+ROS2PublisherSink::~ROS2PublisherSink() = default;
 
 void ROS2PublisherSink::create_publishers(const std::string& topic_prefix)
 {
@@ -53,46 +49,41 @@ void ROS2PublisherSink::create_publishers(const std::string& topic_prefix)
       _p->node_interface, topic_prefix + "/data", data_qos);
 }
 
-void ROS2PublisherSink::addChannel(const std::string& channel_name, const Schema& schema)
+void ROS2PublisherSink::onSchema(const Schema& schema)
 {
-  std::scoped_lock lk(_p->schema_mutex);
-  _p->schemas[channel_name] = schema;
+  _p->schemas[schema.hash] = schema;
   _p->schema_changed = true;
 }
 
-bool ROS2PublisherSink::storeSnapshot(const Snapshot& snapshot)
+void ROS2PublisherSink::onSnapshot(const SnapshotRef& ref)
 {
   // send the schemas, if you haven't yet.
+  if(_p->schema_changed)
   {
-    std::scoped_lock lk(_p->schema_mutex);
-    if(_p->schema_changed)
+    data_tamer_msgs::msg::Schemas msg;
+    msg.schemas.reserve(_p->schemas.size());
+
+    for(const auto& [hash, schema] : _p->schemas)
     {
-      data_tamer_msgs::msg::Schemas msg;
-      msg.schemas.reserve(_p->schemas.size());
+      data_tamer_msgs::msg::Schema schema_msg;
+      schema_msg.hash = hash;
+      schema_msg.channel_name = schema.channel_name;
+      std::ostringstream ss;
+      ss << schema;
+      schema_msg.schema_text = ss.str();
 
-      for(const auto& [channel_name, schema] : _p->schemas)
-      {
-        data_tamer_msgs::msg::Schema schema_msg;
-        schema_msg.hash = schema.hash;
-        schema_msg.channel_name = channel_name;
-        std::ostringstream ss;
-        ss << schema;
-        schema_msg.schema_text = ss.str();
-
-        msg.schemas.push_back(std::move(schema_msg));
-      }
-      _p->schema_publisher->publish(msg);
-      _p->schema_changed = false;  // only once published; a throw leaves it pending
+      msg.schemas.push_back(std::move(schema_msg));
     }
+    _p->schema_publisher->publish(msg);
+    _p->schema_changed = false;  // only once published; a throw leaves it pending
   }
   //----------------------------------------
+  const Snapshot& snapshot = *ref;
   _p->data_msg.timestamp_nsec = uint64_t(snapshot.timestamp.count());
   _p->data_msg.schema_hash = snapshot.schema_hash;
   _p->data_msg.active_mask = snapshot.active_mask;
   _p->data_msg.payload = snapshot.payload;
   _p->data_publisher->publish(_p->data_msg);
-
-  return true;
 }
 
 }  // namespace DataTamer

--- a/data_tamer_cpp/tests/abi_tests.cpp
+++ b/data_tamer_cpp/tests/abi_tests.cpp
@@ -11,13 +11,55 @@
 
 using namespace DataTamer;
 
-TEST(ABI, SinksAreOnlyOnePointerLargerThanTheBase)
+TEST(ABI, SinksAreOnlyOnePointerLargerThanTheInterface)
 {
-  static_assert(sizeof(MCAPSink) == sizeof(DataSinkBase) + sizeof(std::unique_ptr<int>),
-                "MCAPSink grew a member outside its Pimpl");
+  static_assert(sizeof(MCAPSink) == sizeof(DataSink) + sizeof(std::unique_ptr<int>), "MCA"
+                                                                                     "PSi"
+                                                                                     "nk "
+                                                                                     "gre"
+                                                                                     "w "
+                                                                                     "a "
+                                                                                     "mem"
+                                                                                     "ber"
+                                                                                     " ou"
+                                                                                     "tsi"
+                                                                                     "de "
+                                                                                     "its"
+                                                                                     " Pi"
+                                                                                     "mp"
+                                                                                     "l");
 #ifdef USING_ROS2
-  static_assert(sizeof(ROS2PublisherSink) ==
-                    sizeof(DataSinkBase) + sizeof(std::unique_ptr<int>),
-                "ROS2PublisherSink grew a member outside its Pimpl");
+  static_assert(
+      sizeof(ROS2PublisherSink) == sizeof(DataSink) + sizeof(std::unique_ptr<int>), "ROS2"
+                                                                                    "Publ"
+                                                                                    "ishe"
+                                                                                    "rSin"
+                                                                                    "k "
+                                                                                    "grew"
+                                                                                    " a "
+                                                                                    "memb"
+                                                                                    "er "
+                                                                                    "outs"
+                                                                                    "ide "
+                                                                                    "its "
+                                                                                    "Pimp"
+                                                                                    "l");
 #endif
+  static_assert(sizeof(SinkWorker) == 2 * sizeof(std::unique_ptr<int>), "SinkWorker grew "
+                                                                        "a member "
+                                                                        "outside its "
+                                                                        "Pimpl");
+  static_assert(sizeof(SnapshotRef) == sizeof(std::shared_ptr<int>) + sizeof(void*), "Sna"
+                                                                                     "psh"
+                                                                                     "otR"
+                                                                                     "ef "
+                                                                                     "lay"
+                                                                                     "out"
+                                                                                     " is"
+                                                                                     " pa"
+                                                                                     "rt "
+                                                                                     "of "
+                                                                                     "the"
+                                                                                     " AB"
+                                                                                     "I");
 }

--- a/data_tamer_cpp/tests/add_remove_sink_tests.cpp
+++ b/data_tamer_cpp/tests/add_remove_sink_tests.cpp
@@ -1,24 +1,27 @@
 #include "data_tamer/channel.hpp"
 #include "data_tamer/sinks/dummy_sink.hpp"
 
+#include "test_sinks.hpp"
+
 #include <gtest/gtest.h>
 #include <string>
 
 using namespace DataTamer;
 
-void take_snapshots(std::shared_ptr<LogChannel> channel, DummySink& sink, int count)
+void take_snapshots(std::shared_ptr<LogChannel> channel,
+                    const DataTamerTest::Attached<DummySink>& sink, int count)
 {
   for(int i = 0; i < count; i++)
   {
     channel->takeSnapshot();
   }
-  sink.flush();
+  sink.drain();
 }
 
 TEST(DataTamerSinkRegistry, AddSinkIncreasesCountAndRef)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DummySink> sink;
   channel->addDataSink(sink);
 
   std::vector<double> dummyData = { 10, 11, 12 };
@@ -30,14 +33,14 @@ TEST(DataTamerSinkRegistry, AddSinkIncreasesCountAndRef)
 TEST(DataTamerSinkRegistry, SnapshotsAreRecordedWhileSinkPresent)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DummySink> sink;
   channel->addDataSink(sink);
 
   std::vector<double> dummyData = { 10, 11, 12 };
   channel->registerValue("valsA", &dummyData);
 
   const int snapshot_count = 10;
-  take_snapshots(channel, *sink, snapshot_count);
+  take_snapshots(channel, sink, snapshot_count);
 
   const auto hash = channel->getSchema().hash;
   ASSERT_EQ(sink->snapshotsCount(hash), snapshot_count);
@@ -46,14 +49,14 @@ TEST(DataTamerSinkRegistry, SnapshotsAreRecordedWhileSinkPresent)
 TEST(DataTamerSinkRegistry, RemoveSinkStopsRecording)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DummySink> sink;
   channel->addDataSink(sink);
 
   std::vector<double> dummyData = { 10, 11, 12 };
   channel->registerValue("valsA", &dummyData);
 
   const int snapshot_count = 10;
-  take_snapshots(channel, *sink, snapshot_count);
+  take_snapshots(channel, sink, snapshot_count);
 
   const auto hash = channel->getSchema().hash;
   ASSERT_EQ(sink->snapshotsCount(hash), snapshot_count);
@@ -63,7 +66,7 @@ TEST(DataTamerSinkRegistry, RemoveSinkStopsRecording)
   ASSERT_EQ(channel->getNumberOfSinks(), 0);
 
   // Taking more snapshots, should not be recorded in the sink (i.e does not increase snapshots_count)
-  take_snapshots(channel, *sink, snapshot_count);
+  take_snapshots(channel, sink, snapshot_count);
 
   ASSERT_EQ(sink->snapshotsCount(hash), snapshot_count);
 }

--- a/data_tamer_cpp/tests/channel_capacity_tests.cpp
+++ b/data_tamer_cpp/tests/channel_capacity_tests.cpp
@@ -1,6 +1,7 @@
 #include "data_tamer/channel.hpp"
 #include "data_tamer/details/snapshot_pool.hpp"
 #include "alloc_counter.hpp"
+#include "test_sinks.hpp"
 
 #include <gtest/gtest.h>
 #include <chrono>
@@ -12,29 +13,36 @@ using namespace DataTamer;
 
 namespace
 {
-class CapacitySink : public DataSinkBase
+class CapacitySink : public DataSink
 {
 public:
-  CapacitySink() { stopThread(); }
-  ~CapacitySink() override { stopThread(); }
-  using DataSinkBase::processQueuedSnapshots;
   SnapshotRef last;
   size_t received = 0;
-  void addChannel(const std::string&, const Schema&) override {}
-  bool storeSnapshot(const Snapshot&) override
+  void onSchema(const Schema&) override {}
+  void onSnapshot(const SnapshotRef& snapshot) override
   {
     ++received;
-    last = retainSnapshot();
-    return true;
-  }
-  void drain()
-  {
-    processQueuedSnapshots();
-    last.reset();
+    last = snapshot.clone();
   }
 };
 
-struct SizedValue { uint64_t value = 42; };
+/// Manual delivery, with the retained reference released after each drain.
+struct CapacityWorker : DataTamerTest::Attached<CapacitySink>
+{
+  CapacityWorker() : Attached(DataTamerTest::manual<CapacitySink>().worker) {}
+  void drain() const
+  {
+    worker->drain();
+    sink->last.reset();
+  }
+  /// Deliver and keep the last reference, so the slot stays in use.
+  void deliver() const { worker->drain(); }
+};
+
+struct SizedValue
+{
+  uint64_t value = 42;
+};
 class SizedSerializer : public CustomSerializer
 {
 public:
@@ -50,12 +58,14 @@ public:
   size_t serializedSize(const void*) const override
   {
     ++calls;
-    if(throw_size) throw std::runtime_error("size");
+    if(throw_size)
+      throw std::runtime_error("size");
     return size;
   }
   void serialize(const void* source, SerializeMe::SpanBytes& bytes) const override
   {
-    if(throw_serialize) throw std::runtime_error("serialize");
+    if(throw_serialize)
+      throw std::runtime_error("serialize");
     const auto value = static_cast<const SizedValue*>(source)->value;
     std::memcpy(bytes.data(), &value, 8);
     bytes.trimFront(8);
@@ -66,10 +76,12 @@ public:
 TEST(ChannelCapacity, FreezeWithoutSinkReservesAndRejectsSetters)
 {
   auto channel = LogChannel::create("capacity");
-  auto value = channel->createLoggedValue<std::vector<double>>("value", {1.0});
+  auto value = channel->createLoggedValue<std::vector<double>>("value", { 1.0 });
   EXPECT_THROW(channel->setPoolCapacity(0), std::invalid_argument);
-  EXPECT_THROW(channel->setPoolCapacity(std::numeric_limits<size_t>::max()), std::length_error);
-  EXPECT_THROW(channel->setPayloadCapacity(std::numeric_limits<size_t>::max()), std::length_error);
+  EXPECT_THROW(channel->setPoolCapacity(std::numeric_limits<size_t>::max()),
+               std::length_error);
+  EXPECT_THROW(channel->setPayloadCapacity(std::numeric_limits<size_t>::max()),
+               std::length_error);
   channel->setPoolCapacity(2);
   channel->setPayloadCapacity(0);  // Automatic minimum remains valid.
   channel->setStrictMode(true);
@@ -78,7 +90,7 @@ TEST(ChannelCapacity, FreezeWithoutSinkReservesAndRejectsSetters)
   EXPECT_THROW(channel->setPoolCapacity(2), std::runtime_error);
   EXPECT_THROW(channel->setPayloadCapacity(256), std::runtime_error);
   value->set(std::vector<double>(1024, 3.0));
-  auto sink = std::make_shared<CapacitySink>();
+  CapacityWorker sink;
   channel->addDataSink(sink);
   EXPECT_FALSE(channel->takeSnapshot());  // Must use the no-sink freeze's reservation.
   EXPECT_EQ(channel->droppedOversize(), 1u);
@@ -88,7 +100,7 @@ TEST(ChannelCapacity, FreezeWithoutSinkReservesAndRejectsSetters)
 TEST(ChannelCapacity, TwoSlotsExhaustBeforeSizingAndRecover)
 {
   auto channel = LogChannel::create("capacity");
-  auto sink = std::make_shared<CapacitySink>();
+  CapacityWorker sink;
   auto serializer = std::make_shared<SizedSerializer>();
   SizedValue value;
   channel->registerCustomValue("value", &value, serializer);
@@ -100,7 +112,7 @@ TEST(ChannelCapacity, TwoSlotsExhaustBeforeSizingAndRecover)
   EXPECT_FALSE(channel->takeSnapshot());
   EXPECT_EQ(serializer->calls, calls);
   EXPECT_EQ(channel->poolExhausted(), 1u);
-  sink->drain();
+  sink.drain();
   EXPECT_TRUE(channel->takeSnapshot());
   EXPECT_EQ(channel->droppedSnapshots(sink), 0u);
 }
@@ -108,14 +120,14 @@ TEST(ChannelCapacity, TwoSlotsExhaustBeforeSizingAndRecover)
 TEST(ChannelCapacity, StrictDropNonStrictGrowthAndRuntimeToggleUseEachSlotCapacity)
 {
   auto channel = LogChannel::create("capacity");
-  auto sink = std::make_shared<CapacitySink>();
-  auto value = channel->createLoggedValue<std::vector<double>>("value", {1.0});
+  CapacityWorker sink;
+  auto value = channel->createLoggedValue<std::vector<double>>("value", { 1.0 });
   channel->addDataSink(sink);
   channel->setPoolCapacity(2);
   channel->setPayloadCapacity(256);
   channel->setStrictMode(true);
   ASSERT_TRUE(channel->takeSnapshot());
-  sink->drain();
+  sink.drain();
   value->set(std::vector<double>(1024, 3.0));
   EXPECT_FALSE(channel->takeSnapshot());
   EXPECT_EQ(channel->droppedOversize(), 1u);
@@ -123,11 +135,11 @@ TEST(ChannelCapacity, StrictDropNonStrictGrowthAndRuntimeToggleUseEachSlotCapaci
   channel->setStrictMode(false);
   ASSERT_TRUE(channel->takeSnapshot());
   EXPECT_EQ(channel->payloadReallocations(), 1u);
-  sink->drain();
+  sink.drain();
   channel->setStrictMode(true);
   EXPECT_FALSE(channel->takeSnapshot());  // Other slot is still small.
-  ASSERT_TRUE(channel->takeSnapshot());  // Grown slot remains usable in strict mode.
-  sink->processQueuedSnapshots();
+  ASSERT_TRUE(channel->takeSnapshot());   // Grown slot remains usable in strict mode.
+  sink.deliver();
   ASSERT_TRUE(sink->last);
   EXPECT_EQ(sink->last->payload.size(), 8196u);
   uint32_t count = 0;
@@ -140,13 +152,13 @@ TEST(ChannelCapacity, StrictDropNonStrictGrowthAndRuntimeToggleUseEachSlotCapaci
   channel->setStrictMode(false);
   EXPECT_TRUE(channel->takeSnapshot());
   EXPECT_EQ(channel->payloadReallocations(), 2u);
-  sink->drain();
+  sink.drain();
   value->set(std::vector<double>(1500, 4.0));  // Doubled growth provides spare capacity.
   channel->setStrictMode(true);
   for(int i = 0; i < 4; ++i)
   {
     EXPECT_TRUE(channel->takeSnapshot());
-    sink->drain();
+    sink.drain();
   }
   EXPECT_EQ(channel->stats().dropped_oversize, 2u);
   EXPECT_EQ(channel->stats().payload_reallocations, 2u);
@@ -154,22 +166,23 @@ TEST(ChannelCapacity, StrictDropNonStrictGrowthAndRuntimeToggleUseEachSlotCapaci
 
 TEST(ChannelCapacity, ReservationCoversHintDoubleInitialSizeAndMinimum)
 {
-  for(size_t hint : {size_t(0), size_t(4096)})
+  for(size_t hint : { size_t(0), size_t(4096) })
   {
     auto channel = LogChannel::create("capacity");
-    auto sink = std::make_shared<CapacitySink>();
-    auto value = channel->createLoggedValue<std::vector<double>>("value", std::vector<double>(100));
+    CapacityWorker sink;
+    auto value = channel->createLoggedValue<std::vector<double>>(
+        "value", std::vector<double>(100));
     channel->setPoolCapacity(2);
     channel->setPayloadCapacity(hint);
     channel->setStrictMode(true);
     channel->addDataSink(sink);
     ASSERT_TRUE(channel->takeSnapshot());
-    sink->drain();
+    sink.drain();
     value->set(std::vector<double>(hint ? 500 : 200));
     for(int i = 0; i < 4; ++i)
     {
       EXPECT_TRUE(channel->takeSnapshot());
-      sink->drain();
+      sink.drain();
     }
     EXPECT_EQ(channel->payloadReallocations(), 0u);
     EXPECT_EQ(channel->droppedOversize(), 0u);
@@ -179,7 +192,7 @@ TEST(ChannelCapacity, ReservationCoversHintDoubleInitialSizeAndMinimum)
 TEST(ChannelCapacity, DisabledOversizedAndDeadFieldsNeverSizeOrSerialize)
 {
   auto channel = LogChannel::create("capacity");
-  auto sink = std::make_shared<CapacitySink>();
+  CapacityWorker sink;
   auto serializer = std::make_shared<SizedSerializer>();
   auto value = std::make_unique<SizedValue>();
   auto id = channel->registerCustomValue("value", value.get(), serializer);
@@ -192,7 +205,7 @@ TEST(ChannelCapacity, DisabledOversizedAndDeadFieldsNeverSizeOrSerialize)
   value.reset();
   channel->setEnabled(id, true);
   ASSERT_TRUE(channel->takeSnapshot());
-  sink->processQueuedSnapshots();
+  sink.deliver();
   ASSERT_TRUE(sink->last);
   EXPECT_FALSE(GetBit(sink->last->active_mask, 0));
   EXPECT_TRUE(sink->last->payload.empty());
@@ -202,11 +215,11 @@ TEST(ChannelCapacity, DisabledOversizedAndDeadFieldsNeverSizeOrSerialize)
 
 TEST(ChannelCapacity, ExceptionsReleaseSingleSlotAndEpochEvenInStrictMode)
 {
-  for(bool strict : {false, true})
-    for(bool sizing : {false, true})
+  for(bool strict : { false, true })
+    for(bool sizing : { false, true })
     {
       auto channel = LogChannel::create("capacity");
-      auto sink = std::make_shared<CapacitySink>();
+      CapacityWorker sink;
       auto serializer = std::make_shared<SizedSerializer>();
       SizedValue value;
       auto id = channel->registerCustomValue("value", &value, serializer);
@@ -214,7 +227,7 @@ TEST(ChannelCapacity, ExceptionsReleaseSingleSlotAndEpochEvenInStrictMode)
       channel->setStrictMode(strict);
       channel->addDataSink(sink);
       ASSERT_TRUE(channel->takeSnapshot());
-      sink->drain();
+      sink.drain();
       serializer->throw_size = sizing;
       serializer->throw_serialize = !sizing;
       EXPECT_THROW(channel->takeSnapshot(), std::runtime_error);
@@ -229,7 +242,7 @@ TEST(ChannelCapacity, ExceptionsReleaseSingleSlotAndEpochEvenInStrictMode)
 TEST(ChannelCapacity, ImpossibleSizesFailSafelyAndFreezeCanRetry)
 {
   auto channel = LogChannel::create("capacity");
-  auto sink = std::make_shared<CapacitySink>();
+  CapacityWorker sink;
   auto serializer = std::make_shared<SizedSerializer>();
   SizedValue value;
   auto id = channel->registerCustomValue("value", &value, serializer);
@@ -241,7 +254,7 @@ TEST(ChannelCapacity, ImpossibleSizesFailSafelyAndFreezeCanRetry)
   EXPECT_THROW(channel->setPayloadCapacity(256), std::runtime_error);
   serializer->size = 8;
   ASSERT_TRUE(channel->takeSnapshot());
-  sink->drain();
+  sink.drain();
   // Each size fits the byte vector, but their sum cannot be doubled.
   serializer->size = std::vector<uint8_t>().max_size() / 2;
   EXPECT_THROW(channel->takeSnapshot(), std::length_error);
@@ -257,9 +270,9 @@ TEST(ChannelCapacity, ImpossibleSizesFailSafelyAndFreezeCanRetry)
 TEST(ChannelCapacity, TenThousandDirtySnapshotsWithControlChurnDoNotAllocate)
 {
   auto channel = LogChannel::create(std::string(128, 'c'));
-  auto first = std::make_shared<CapacitySink>();
-  auto second = std::make_shared<CapacitySink>();
-  auto changing = std::make_shared<CapacitySink>();
+  CapacityWorker first;
+  CapacityWorker second;
+  CapacityWorker changing;
   uint64_t value = 42;
   auto id = channel->registerValue("value", &value);
   auto logged = channel->createLoggedValue<uint64_t>("changing", 42);
@@ -267,19 +280,20 @@ TEST(ChannelCapacity, TenThousandDirtySnapshotsWithControlChurnDoNotAllocate)
   channel->addDataSink(second);
   channel->setStrictMode(true);
   ASSERT_TRUE(channel->takeSnapshot());
-  first->drain();
-  second->drain();
-  std::atomic<bool> start{false}, done{false};
-  std::atomic<size_t> churn{0};
+  first.drain();
+  second.drain();
+  std::atomic<bool> start{ false }, done{ false };
+  std::atomic<size_t> churn{ 0 };
   std::thread control([&] {
-    while(!start) std::this_thread::yield();
+    while(!start)
+      std::this_thread::yield();
     do
     {
       logged.reset();
       logged = channel->createLoggedValue<uint64_t>("changing", 42);
       channel->addDataSink(changing);
       channel->removeDataSink(changing);
-      changing->drain();
+      changing.drain();
       ++churn;
     } while(!done);
   });
@@ -297,13 +311,14 @@ TEST(ChannelCapacity, TenThousandDirtySnapshotsWithControlChurnDoNotAllocate)
         allocations += scope.allocations();
         deallocations += scope.deallocations();
       }
-      first->drain();
-      second->drain();
+      first.drain();
+      second.drain();
     }
     if(batch != 9)
     {
       const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
-      while(churn.load() <= completed_churn && std::chrono::steady_clock::now() < deadline)
+      while(churn.load() <= completed_churn &&
+            std::chrono::steady_clock::now() < deadline)
         std::this_thread::yield();
       ASSERT_GT(churn.load(), completed_churn) << "control thread stalled";
       completed_churn = churn.load();
@@ -321,16 +336,16 @@ TEST(ChannelCapacity, TenThousandDirtySnapshotsWithControlChurnDoNotAllocate)
 TEST(ChannelCapacity, AutomaticMinimumAndStrictDropRecoverAfterShrink)
 {
   auto channel = LogChannel::create("capacity");
-  auto sink = std::make_shared<CapacitySink>();
+  CapacityWorker sink;
   auto value = channel->createLoggedValue<std::vector<double>>("value");
   channel->setPoolCapacity(2);
   channel->setStrictMode(true);
   channel->addDataSink(sink);
   ASSERT_TRUE(channel->takeSnapshot());
-  sink->drain();
+  sink.drain();
   value->set(std::vector<double>(31));  // 4-byte length + 248 bytes fits the minimum.
   EXPECT_TRUE(channel->takeSnapshot());
-  sink->drain();
+  sink.drain();
   value->set(std::vector<double>(32));  // 260 bytes exceeds both initial slots.
   EXPECT_FALSE(channel->takeSnapshot());
   value->set(std::vector<double>(1));

--- a/data_tamer_cpp/tests/channel_control_tests.cpp
+++ b/data_tamer_cpp/tests/channel_control_tests.cpp
@@ -1,6 +1,8 @@
 #include "data_tamer/channel.hpp"
 #include "data_tamer/details/snapshot_pool.hpp"
 
+#include "test_sinks.hpp"
+
 #include <gtest/gtest.h>
 #include <condition_variable>
 #include <cstring>
@@ -10,6 +12,7 @@
 #include <thread>
 
 using namespace DataTamer;
+using DataTamerTest::Attached;
 
 namespace
 {
@@ -103,20 +106,16 @@ public:
   }
 };
 
-class ControlSink : public DataSinkBase
+class ControlSink : public DataSink
 {
 public:
-  ControlSink() { stopThread(); }
-  ~ControlSink() override { stopThread(); }
-  using DataSinkBase::processQueuedSnapshots;
-  using DataSinkBase::retainSnapshot;
   Gate* add_gate = nullptr;
   bool reject_schema = false;
   size_t registrations = 0;
   Schema schema;
   std::vector<Snapshot> snapshots;
-  std::function<void()> on_store;
-  void addChannel(const std::string&, const Schema& value) override
+  std::function<void(const SnapshotRef&)> on_store;
+  void onSchema(const Schema& value) override
   {
     if(add_gate)
       add_gate->pause();
@@ -125,14 +124,19 @@ public:
     ++registrations;
     schema = value;
   }
-  bool storeSnapshot(const Snapshot& value) override
+  void onSnapshot(const SnapshotRef& value) override
   {
-    snapshots.push_back(value);
+    snapshots.push_back(*value);
     if(on_store)
-      on_store();
-    return true;
+      on_store(value);
   }
 };
+
+/// Manual delivery: snapshots reach the sink only when the test drains it.
+Attached<ControlSink> controlSink()
+{
+  return DataTamerTest::manual<ControlSink>();
+}
 
 void checkPayloads(const ControlSink& sink, size_t fields)
 {
@@ -160,19 +164,19 @@ TEST(ChannelControl, EightSinksDuplicateAndRemoval)
   auto channel = LogChannel::create("control");
   uint64_t value = 42;
   channel->registerValue("value", &value);
-  std::vector<std::shared_ptr<ControlSink>> sinks;
+  std::vector<Attached<ControlSink>> sinks;
   for(int i = 0; i < 8; ++i)
   {
-    sinks.push_back(std::make_shared<ControlSink>());
+    sinks.push_back(controlSink());
     channel->addDataSink(sinks.back());
   }
   channel->addDataSink(sinks.front());
   EXPECT_EQ(channel->getNumberOfSinks(), 8u);
-  EXPECT_THROW(channel->addDataSink(std::make_shared<ControlSink>()), std::runtime_error);
+  EXPECT_THROW(channel->addDataSink(controlSink()), std::runtime_error);
   ASSERT_TRUE(channel->takeSnapshot());
   for(auto& sink : sinks)
   {
-    sink->processQueuedSnapshots();
+    sink.drain();
     EXPECT_EQ(sink->registrations, 1u);
     EXPECT_EQ(sink->schema.hash, channel->getSchema().hash);
     EXPECT_EQ(sink->snapshots.size(), 1u);
@@ -181,7 +185,7 @@ TEST(ChannelControl, EightSinksDuplicateAndRemoval)
   channel->removeDataSink(sinks.front());
   channel->removeDataSink(sinks.front());
   ASSERT_TRUE(channel->takeSnapshot());
-  sinks.front()->processQueuedSnapshots();
+  sinks.front().drain();
   EXPECT_EQ(sinks.front()->snapshots.size(), 1u);
   EXPECT_EQ(channel->getNumberOfSinks(), 7u);
 }
@@ -205,7 +209,7 @@ TEST(ChannelControl, FirstCallWithoutSinksFreezesSchema)
 TEST(ChannelControl, StaleIdCannotResurrectDetachedValueAndTypesRemainChecked)
 {
   auto channel = LogChannel::create("control");
-  auto sink = std::make_shared<ControlSink>();
+  auto sink = controlSink();
   auto value = std::make_unique<uint64_t>(42);
   auto id = channel->registerValue("value", value.get());
   channel->addDataSink(sink);
@@ -215,7 +219,7 @@ TEST(ChannelControl, StaleIdCannotResurrectDetachedValueAndTypesRemainChecked)
   channel->setEnabled(id, true);
   EXPECT_FALSE(channel->sharedState()->isEnabled(id.first_index));
   ASSERT_TRUE(channel->takeSnapshot());
-  sink->processQueuedSnapshots();
+  sink.drain();
   EXPECT_FALSE(GetBit(sink->snapshots.back().active_mask, 0));
   EXPECT_TRUE(sink->snapshots.back().payload.empty());
   EXPECT_EQ(channel->getActiveFlags(), sink->snapshots.back().active_mask);
@@ -226,14 +230,14 @@ TEST(ChannelControl, StaleIdCannotResurrectDetachedValueAndTypesRemainChecked)
   auto next = channel->registerValue("value", &replacement);
   EXPECT_EQ(next.first_index, id.first_index);
   ASSERT_TRUE(channel->takeSnapshot());
-  sink->processQueuedSnapshots();
+  sink.drain();
   checkPayloads(*sink, 1);
 }
 
 TEST(ChannelControl, UnregisterWaitsForPausedReaderBeforeValueDestruction)
 {
   auto channel = LogChannel::create("control");
-  auto sink = std::make_shared<ControlSink>();
+  auto sink = controlSink();
   auto value = std::make_unique<CustomValue>();
   auto serializer = std::make_shared<PausedSerializer>();
   auto id = channel->registerCustomValue("value", value.get(), serializer);
@@ -262,7 +266,7 @@ TEST(ChannelControl, UnregisterWaitsForPausedReaderBeforeValueDestruction)
   serializer->gate = nullptr;
   channel->setEnabled(id, true);
   EXPECT_TRUE(channel->takeSnapshot());
-  sink->processQueuedSnapshots();
+  sink.drain();
   EXPECT_FALSE(GetBit(sink->snapshots.back().active_mask, 0));
   EXPECT_TRUE(sink->snapshots.back().payload.empty());
 }
@@ -270,13 +274,13 @@ TEST(ChannelControl, UnregisterWaitsForPausedReaderBeforeValueDestruction)
 TEST(ChannelControl, BlockedAddChannelDoesNotBlockExistingSnapshots)
 {
   auto channel = LogChannel::create("control");
-  auto existing = std::make_shared<ControlSink>();
+  auto existing = controlSink();
   uint64_t value = 42;
   channel->registerValue("value", &value);
   channel->addDataSink(existing);
   ASSERT_TRUE(channel->takeSnapshot());
   Gate gate;
-  auto added = std::make_shared<ControlSink>();
+  auto added = controlSink();
   added->add_gate = &gate;
   auto add = std::async(std::launch::async, [&] { channel->addDataSink(added); });
   EXPECT_TRUE(gate.wait());
@@ -285,10 +289,10 @@ TEST(ChannelControl, BlockedAddChannelDoesNotBlockExistingSnapshots)
   gate.release();
   add.get();
   EXPECT_TRUE(snapshot.get());
-  existing->processQueuedSnapshots();
+  existing.drain();
   EXPECT_EQ(existing->snapshots.size(), 2u);
   EXPECT_TRUE(channel->takeSnapshot());
-  added->processQueuedSnapshots();
+  added.drain();
   EXPECT_EQ(added->registrations, 1u);
   EXPECT_FALSE(added->snapshots.empty());
 }
@@ -299,7 +303,7 @@ TEST(ChannelControl, BlockedAddChannelDoesNotBlockExistingSnapshots)
 TEST(ChannelControl, RemovalWaitsForPausedReaderAndReferencesSurvive)
 {
   auto channel = LogChannel::create("control");
-  auto sink = std::make_shared<ControlSink>();
+  auto sink = controlSink();
   CustomValue value;
   auto serializer = std::make_shared<PausedSerializer>();
   channel->registerCustomValue("value", &value, serializer);
@@ -317,21 +321,20 @@ TEST(ChannelControl, RemovalWaitsForPausedReaderAndReferencesSurvive)
   EXPECT_EQ(channel->getNumberOfSinks(), 0u);
   channel.reset();
   SnapshotRef retained;
-  sink->on_store = [&] { retained = sink->retainSnapshot(); };
-  sink->processQueuedSnapshots();
+  sink->on_store = [&](const SnapshotRef& ref) { retained = ref.clone(); };
+  sink.drain();
   EXPECT_EQ(sink->snapshots.size(), 2u);
   checkPayloads(*sink, 1);
-  sink.reset();
+  sink.worker.reset();
   ASSERT_TRUE(retained);
-  EXPECT_EQ(retained->channel_name, "control");
   EXPECT_EQ(retained->payload.size(), 8u);
 }
 
 TEST(ChannelControl, FailedFreezeRetriesAllLinksAndStillFreezesSchema)
 {
   auto channel = LogChannel::create("control");
-  auto good = std::make_shared<ControlSink>();
-  auto failing = std::make_shared<ControlSink>();
+  auto good = controlSink();
+  auto failing = controlSink();
   uint64_t value = 42;
   channel->registerValue("value", &value);
   channel->addDataSink(failing);
@@ -343,13 +346,13 @@ TEST(ChannelControl, FailedFreezeRetriesAllLinksAndStillFreezesSchema)
   EXPECT_TRUE(channel->takeSnapshot());
   EXPECT_EQ(good->registrations, 1u);
   EXPECT_EQ(failing->registrations, 1u);
-  auto rejected = std::make_shared<ControlSink>();
+  auto rejected = controlSink();
   rejected->reject_schema = true;
   EXPECT_THROW(channel->addDataSink(rejected), std::runtime_error);
   EXPECT_EQ(channel->getNumberOfSinks(), 2u);
   EXPECT_TRUE(channel->takeSnapshot());
-  good->processQueuedSnapshots();
-  failing->processQueuedSnapshots();
+  good.drain();
+  failing.drain();
   EXPECT_EQ(good->snapshots.size(), 2u);
   EXPECT_EQ(failing->snapshots.size(), 2u);
 }
@@ -357,7 +360,7 @@ TEST(ChannelControl, FailedFreezeRetriesAllLinksAndStillFreezesSchema)
 TEST(ChannelControl, RejectedCustomRegistrationDoesNotMutateFrozenSchema)
 {
   auto channel = LogChannel::create("control");
-  auto sink = std::make_shared<ControlSink>();
+  auto sink = controlSink();
   RegisteredCustom value;
   auto id = channel->registerValue("value", &value);
   channel->addDataSink(sink);
@@ -380,8 +383,8 @@ TEST(ChannelControl, RejectedCustomRegistrationDoesNotMutateFrozenSchema)
 TEST(ChannelControl, ConcurrentChurnTogglesAndSinkChangesPreservePayloads)
 {
   auto channel = LogChannel::create("control");
-  auto stable = std::make_shared<ControlSink>();
-  auto changing = std::make_shared<ControlSink>();
+  auto stable = controlSink();
+  auto changing = controlSink();
   auto logged = channel->createLoggedValue<uint64_t>("logged", 42);
   RegisteredCustom value;
   auto custom_id = channel->registerValue("custom", &value);
@@ -420,14 +423,14 @@ TEST(ChannelControl, ConcurrentChurnTogglesAndSinkChangesPreservePayloads)
   do
   {
     channel->takeSnapshot();
-    stable->processQueuedSnapshots();
-    changing->processQueuedSnapshots();
+    stable.drain();
+    changing.drain();
   } while(!done);
   control.join();
   second_control.join();
   toggler.join();
-  stable->processQueuedSnapshots();
-  changing->processQueuedSnapshots();
+  stable.drain();
+  changing.drain();
   checkPayloads(*stable, 3);
   checkPayloads(*changing, 3);
   EXPECT_FALSE(stable->snapshots.empty());
@@ -438,23 +441,23 @@ TEST(ChannelControl, SerializerExceptionsLeaveEpochAndPoolReusable)
   for(bool size_pass : { false, true })
   {
     auto channel = LogChannel::create("control");
-    auto sink = std::make_shared<ControlSink>();
+    auto sink = controlSink();
     CustomValue value;
     auto serializer = std::make_shared<PausedSerializer>();
     auto id = channel->registerCustomValue("value", &value, serializer);
     channel->addDataSink(sink);
     channel->setPoolCapacity(1);  // a slot leaked by the throw would fail the next call
     ASSERT_TRUE(channel->takeSnapshot());
-    sink->processQueuedSnapshots();
+    sink.drain();
     serializer->throw_size = size_pass;
     serializer->throw_serialize = !size_pass;
     EXPECT_THROW(channel->takeSnapshot(), std::runtime_error);
     serializer->throw_size = serializer->throw_serialize = false;
     EXPECT_TRUE(channel->takeSnapshot());
-    sink->processQueuedSnapshots();
+    sink.drain();
     channel->unregister(id);
     EXPECT_TRUE(channel->takeSnapshot());
-    sink->processQueuedSnapshots();
+    sink.drain();
     EXPECT_EQ(channel->poolExhausted(), 0u);
     EXPECT_EQ(sink->snapshots.size(), 3u);
     checkPayloads(*sink, 1);
@@ -464,7 +467,7 @@ TEST(ChannelControl, SerializerExceptionsLeaveEpochAndPoolReusable)
 TEST(ChannelControl, ExhaustedPoolDoesNotCallSerializer)
 {
   auto channel = LogChannel::create("control");
-  auto sink = std::make_shared<ControlSink>();
+  auto sink = controlSink();
   CustomValue value;
   auto serializer = std::make_shared<PausedSerializer>();
   channel->registerCustomValue("value", &value, serializer);

--- a/data_tamer_cpp/tests/custom_types_tests.cpp
+++ b/data_tamer_cpp/tests/custom_types_tests.cpp
@@ -2,6 +2,7 @@
 #include "data_tamer/sinks/dummy_sink.hpp"
 
 #include "../examples/geometry_types.hpp"
+#include "test_sinks.hpp"
 
 #include <gtest/gtest.h>
 
@@ -42,7 +43,7 @@ std::string_view TypeDefinition(TestType& obj, AddField& add)
 TEST(DataTamerCustom, Registration)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> sink;
   channel->addDataSink(sink);
 
   Pose poseA;
@@ -64,7 +65,7 @@ TEST(DataTamerCustom, Registration)
 TEST(DataTamerCustom, CustomType1)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> sink;
   channel->addDataSink(sink);
 
   Pose pose = { { 1, 2, 3 }, { 4, 5, 6, 7 } };
@@ -75,7 +76,7 @@ TEST(DataTamerCustom, CustomType1)
   channel->registerValue("test_value", &my_test);
 
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
 
   auto expected_size = sizeof(Pose) + sizeof(double) + sizeof(int32_t) +
                        sizeof(uint32_t) + 4 * sizeof(Point3D) + sizeof(TestType::Color) +
@@ -137,7 +138,7 @@ TEST(DataTamerCustom, CustomType1)
 TEST(DataTamerCustom, CustomType2)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> sink;
   channel->addDataSink(sink);
 
   std::array<Point3D, 2> points;
@@ -147,7 +148,7 @@ TEST(DataTamerCustom, CustomType2)
   channel->registerValue("quats", &quats);
 
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
 
   auto expected_size = 2 * sizeof(Point3D) + 3 * sizeof(Quaternion) + sizeof(uint32_t);
 
@@ -221,7 +222,7 @@ public:
 TEST(DataTamerCustom, CustomType3)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> sink;
   channel->addDataSink(sink);
 
   auto serializer = std::make_shared<Pos2D_Serializer>();
@@ -240,7 +241,7 @@ TEST(DataTamerCustom, CustomType3)
   channel->registerCustomValue("v3", &v3, serializer);
 
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
 
   const auto expected_size = 6 * sizeof(Pos2D) + sizeof(uint32_t);
 
@@ -272,14 +273,14 @@ TEST(DataTamerCustom, CustomType3)
 TEST(DataTamerCustom, RegisterConstMethods)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> sink;
   channel->addDataSink(sink);
 
   PseudoEigen::Vector2d vect = { 1, 2 };
   channel->registerValue("vect", &vect);
 
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
 
   const auto expected_size = 2 * sizeof(double);
 
@@ -335,12 +336,12 @@ std::string_view TypeDefinition(Chassis& c, AddField& add)
 TEST(DataTamerCustom, FixedSizeOfNestedFixedArraysMatchesPayload)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> sink;
   channel->addDataSink(sink);
   Chassis chassis;
   channel->registerValue("chassis", &chassis);
   ASSERT_TRUE(channel->takeSnapshot());
-  sink->flush();
+  sink.drain();
   const size_t expected = 4 * (3 * sizeof(double) + 2 * sizeof(int32_t)) + sizeof(double);
   EXPECT_EQ(sink->latestPayloadSize(), expected);
 }

--- a/data_tamer_cpp/tests/dt_tests.cpp
+++ b/data_tamer_cpp/tests/dt_tests.cpp
@@ -1,6 +1,7 @@
 #include "data_tamer/data_tamer.hpp"
 #include "data_tamer/sinks/dummy_sink.hpp"
 #include "data_tamer/sinks/mcap_sink.hpp"
+#include "test_sinks.hpp"
 
 #include <gtest/gtest.h>
 
@@ -22,8 +23,8 @@ TEST(DataTamerBasic, BasicTypes)
 
 TEST(DataTamerBasic, SinkAdd)
 {
-  auto dummy_sink_A = std::make_shared<DummySink>();
-  auto dummy_sink_B = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> dummy_sink_A;
+  DataTamerTest::Attached<DataTamer::DummySink> dummy_sink_B;
 
   ChannelsRegistry registry;
   registry.addDefaultSink(dummy_sink_A);
@@ -42,8 +43,8 @@ TEST(DataTamerBasic, SinkAdd)
     channel->takeSnapshot();
   }
 
-  dummy_sink_A->flush();
-  dummy_sink_B->flush();
+  dummy_sink_A.drain();
+  dummy_sink_B.drain();
 
   const auto hash = channel->getSchema().hash;
 
@@ -89,7 +90,7 @@ TEST(DataTamerBasic, SerializeVariant)
 TEST(DataTamerBasic, TestRegistration)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> sink;
   channel->addDataSink(sink);
 
   double v1 = 69.0;
@@ -114,7 +115,7 @@ TEST(DataTamerBasic, TestRegistration)
   id_v2 = channel->registerValue("v2", &v2_bis);
 
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
 
   // changing the pointer after takeSnapshot is valid
   channel->unregister(id_i2);
@@ -134,7 +135,7 @@ TEST(DataTamerBasic, TestRegistration)
   channel->setEnabled(id_i1, false);
 
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
 
   // payload should contain v2, and i2
   auto reduced_size = sizeof(double) + sizeof(int32_t);
@@ -146,7 +147,7 @@ TEST(DataTamerBasic, TestRegistration)
   channel->setEnabled(id_i1, true);
 
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
 
   ASSERT_EQ(sink->latestPayloadSize(), expected_size);
 }
@@ -154,7 +155,7 @@ TEST(DataTamerBasic, TestRegistration)
 TEST(DataTamerBasic, Vector)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> sink;
   channel->addDataSink(sink);
 
   std::vector<float> vect = { 1, 2, 3, 4 };
@@ -164,14 +165,14 @@ TEST(DataTamerBasic, Vector)
   const auto expected_size = 4 * sizeof(float) + sizeof(uint32_t);
 
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
   ASSERT_EQ(sink->latestPayloadSize(), expected_size);
 }
 
 TEST(DataTamerBasic, Disable)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> sink;
   channel->addDataSink(sink);
 
   double v1 = 11;
@@ -194,14 +195,14 @@ TEST(DataTamerBasic, Disable)
                          3 * sizeof(double) + 4 * sizeof(float) + sizeof(uint32_t);
 
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
   ASSERT_EQ(sink->latestPayloadSize(), expected_size);
   ASSERT_EQ(sink->latestActiveMask()[0], 0b11111111);
 
   auto checkSize = [&](const auto& id, size_t size) {
     channel->setEnabled(id, false);
     channel->takeSnapshot();
-    sink->flush();
+    sink.drain();
     channel->setEnabled(id, true);
 
     size_t expected = expected_size - size;
@@ -233,16 +234,15 @@ TEST(DataTamerBasic, Disable)
 TEST(DataTamerBasic, VectorWithChangingSize)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> sink;
   channel->addDataSink(sink);
 
   std::vector<float> vect = { 1, 2, 3, 4 };
   channel->registerValue("vect", &vect);
 
   channel->takeSnapshot();
-  sink->flush();
-  ASSERT_EQ(sink->latestPayloadSize(),
-            vect.size() * sizeof(float) + sizeof(uint32_t));
+  sink.drain();
+  ASSERT_EQ(sink->latestPayloadSize(), vect.size() * sizeof(float) + sizeof(uint32_t));
 
   // if we push more elements into the vector, it should
   // work, even if there is a new allocation of memory
@@ -252,17 +252,15 @@ TEST(DataTamerBasic, VectorWithChangingSize)
   }
 
   channel->takeSnapshot();
-  sink->flush();
-  ASSERT_EQ(sink->latestPayloadSize(),
-            vect.size() * sizeof(float) + sizeof(uint32_t));
+  sink.drain();
+  ASSERT_EQ(sink->latestPayloadSize(), vect.size() * sizeof(float) + sizeof(uint32_t));
 
   // same is the vector size is reduced
   vect.resize(5);
 
   channel->takeSnapshot();
-  sink->flush();
-  ASSERT_EQ(sink->latestPayloadSize(),
-            vect.size() * sizeof(float) + sizeof(uint32_t));
+  sink.drain();
+  ASSERT_EQ(sink->latestPayloadSize(), vect.size() * sizeof(float) + sizeof(uint32_t));
 }
 
 TEST(DataTamerBasic, LockedPtr)
@@ -301,7 +299,7 @@ TEST(DataTamerBasic, FinishQueue)
   auto const temp_path =
       std::filesystem::temp_directory_path() / std::filesystem::path("data_tamer_test."
                                                                      "mcap");
-  auto sink = std::make_shared<MCAPSink>(temp_path.string());
+  DataTamerTest::Attached<MCAPSink> sink(temp_path.string());
   channel->addDataSink(sink);
 
   double const value = 1.;
@@ -309,13 +307,15 @@ TEST(DataTamerBasic, FinishQueue)
 
   EXPECT_TRUE(channel->takeSnapshot());
 
-  sink->finishQueueAndStop();
+  sink.worker->stop();
+  sink->stopRecording();
 
   // now we shouldn't be able to take more snapshots
   EXPECT_FALSE(channel->takeSnapshot());
 
   // restart the recording
   sink->restartRecording(temp_path);
+  sink.worker->start();
 
   EXPECT_TRUE(channel->takeSnapshot());
 

--- a/data_tamer_cpp/tests/logged_value_tests.cpp
+++ b/data_tamer_cpp/tests/logged_value_tests.cpp
@@ -1,5 +1,6 @@
 #include "data_tamer/data_tamer.hpp"
 #include "data_tamer/sinks/dummy_sink.hpp"
+#include "test_sinks.hpp"
 #include "alloc_counter.hpp"
 
 #include <gtest/gtest.h>
@@ -55,11 +56,11 @@ TEST(LoggedValue, ScalarTraitSelectsAtomics)
 TEST(LoggedValue, ScalarSetIsSeenBySnapshotAndDoesNotAllocate)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DummySink> sink;
   channel->addDataSink(sink);
   auto v = channel->createLoggedValue<double>("v", 1.0);
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
 
   {
     AllocCounter::Scope scope;
@@ -72,7 +73,7 @@ TEST(LoggedValue, ScalarSetIsSeenBySnapshotAndDoesNotAllocate)
   ASSERT_EQ(v->get(), 999.0);
 
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
   const auto snap = sink->latestSnapshot();
   ASSERT_EQ(snap.payload.size(), sizeof(double));
   double stored = 0;
@@ -115,17 +116,17 @@ TEST(LoggedValue, SetEnabledFromWriterThreadNeedsNoChannel)
 TEST(LoggedValue, AutoEnableOnSetDirtiesMask)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DummySink> sink;
   channel->addDataSink(sink);
   auto v = channel->createLoggedValue<double>("v", 1.0);
   v->setEnabled(false);
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
   ASSERT_EQ(sink->latestPayloadSize(), 0u);
 
   v->set(2.0);  // auto_enable defaults to true
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
   ASSERT_EQ(sink->latestPayloadSize(), sizeof(double));
 }
 
@@ -135,31 +136,28 @@ TEST(LoggedValue, AutoEnableOnSetDirtiesMask)
 namespace
 {
 // Every delivered 8-byte payload must have all bytes equal (see the writer below).
-class TearingSink : public DataSinkBase
+class TearingSink : public DataSink
 {
 public:
-  ~TearingSink() override { stopThread(); }
-  using DataSinkBase::processQueuedSnapshots;
   std::atomic<size_t> checked{ 0 };
   std::atomic<size_t> torn{ 0 };
-  void addChannel(const std::string&, const Schema&) override {}
-  bool storeSnapshot(const Snapshot& snapshot) override
+  void onSchema(const Schema&) override {}
+  void onSnapshot(const SnapshotRef& snapshot) override
   {
     uint64_t seen = 0;
-    if(snapshot.payload.size() != sizeof(seen))
+    if(snapshot->payload.size() != sizeof(seen))
     {
       torn++;
-      return false;
+      return;
     }
-    std::memcpy(&seen, snapshot.payload.data(), sizeof(seen));
+    std::memcpy(&seen, snapshot->payload.data(), sizeof(seen));
     for(int b = 1; b < 8; b++)
       if(((seen >> (8 * b)) & 0xFF) != (seen & 0xFF))
       {
         torn++;
-        return false;
+        return;
       }
     checked++;
-    return true;
   }
 };
 }  // namespace
@@ -167,7 +165,7 @@ public:
 TEST(LoggedValue, ScalarWriterRacesSnapshotCleanly)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<TearingSink>();
+  DataTamerTest::Attached<TearingSink> sink;
   channel->addDataSink(sink);
   auto v = channel->createLoggedValue<uint64_t>("v", 0);
   channel->takeSnapshot();
@@ -193,7 +191,7 @@ TEST(LoggedValue, ScalarWriterRacesSnapshotCleanly)
   }
   stop = true;
   writer.join();
-  sink->processQueuedSnapshots();
+  sink.worker->stop();
   ASSERT_EQ(sink->torn.load(), 0u);
   ASSERT_GT(sink->checked.load(), 0u);  // a full queue may have dropped some
 }
@@ -201,7 +199,7 @@ TEST(LoggedValue, ScalarWriterRacesSnapshotCleanly)
 TEST(LoggedValue, NonScalarStillWorksThroughMutablePtr)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DummySink> sink;
   channel->addDataSink(sink);
   auto v = channel->createLoggedValue<std::vector<double>>("vec", { 1.0, 2.0 });
   {
@@ -213,7 +211,7 @@ TEST(LoggedValue, NonScalarStillWorksThroughMutablePtr)
   }
   ASSERT_EQ(v->get().size(), 3u);
   channel->takeSnapshot();
-  sink->flush();
+  sink.drain();
   ASSERT_EQ(sink->latestPayloadSize(), sizeof(uint32_t) + 3 * sizeof(double));
 }
 
@@ -223,7 +221,7 @@ TEST(LoggedValue, NonScalarStillWorksThroughMutablePtr)
 TEST(LoggedValue, NonScalarProxyExcludesSnapshot)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<DummySink>();
+  DataTamerTest::Attached<DummySink> sink;
   channel->addDataSink(sink);
   auto v = channel->createLoggedValue<std::vector<double>>("vec");
   channel->takeSnapshot();

--- a/data_tamer_cpp/tests/parser_tests.cpp
+++ b/data_tamer_cpp/tests/parser_tests.cpp
@@ -2,6 +2,7 @@
 #include "data_tamer/data_tamer.hpp"
 #include "data_tamer/sinks/dummy_sink.hpp"
 #include "../examples/geometry_types.hpp"
+#include "test_sinks.hpp"
 
 #include <gtest/gtest.h>
 #include <thread>
@@ -136,7 +137,7 @@ SnapshotView ConvertSnapshot(const DataTamer::Snapshot& snapshot)
 TEST(DataTamerParser, PlainParsing)
 {
   auto channel = DataTamer::LogChannel::create("channel");
-  auto dummy_sink = std::make_shared<DataTamer::DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> dummy_sink;
   channel->addDataSink(dummy_sink);
 
   int32_t v1 = 5;
@@ -150,7 +151,7 @@ TEST(DataTamerParser, PlainParsing)
   channel->registerValue("v4", &v4);
 
   channel->takeSnapshot();
-  dummy_sink->flush();
+  dummy_sink.drain();
 
   const auto& schema_in = channel->getSchema();
   const auto& schema_out = DataTamerParser::BuilSchemaFromText(ToStr(schema_in));
@@ -181,7 +182,7 @@ TEST(DataTamerParser, CustomParsing)
 {
   DataTamer::ChannelsRegistry registry;
   auto channel = registry.getChannel("channel");
-  auto dummy_sink = std::make_shared<DataTamer::DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> dummy_sink;
   channel->addDataSink(dummy_sink);
 
   Pose pose;
@@ -190,7 +191,7 @@ TEST(DataTamerParser, CustomParsing)
   channel->registerValue("pose", &pose);
 
   channel->takeSnapshot();
-  dummy_sink->flush();
+  dummy_sink.drain();
 
   const auto& schema_in = channel->getSchema();
   const auto& schema_out = DataTamerParser::BuilSchemaFromText(ToStr(schema_in));
@@ -225,7 +226,7 @@ TEST(DataTamerParser, VectorParsing)
 {
   DataTamer::ChannelsRegistry registry;
   auto channel = registry.getChannel("channel");
-  auto dummy_sink = std::make_shared<DataTamer::DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> dummy_sink;
   channel->addDataSink(dummy_sink);
 
   std::vector<double> valsA = { 10, 11, 12 };
@@ -245,7 +246,7 @@ TEST(DataTamerParser, VectorParsing)
   channel->registerValue("quats", &quats);
 
   channel->takeSnapshot();
-  dummy_sink->flush();
+  dummy_sink.drain();
 
   const auto& schema_in = channel->getSchema();
   const auto& schema_out = DataTamerParser::BuilSchemaFromText(ToStr(schema_in));
@@ -342,10 +343,10 @@ TEST(DataTamerParser, RejectsMalformedInput)
   std::vector<double> samples = { 1.0, 2.0 };
   channel->registerValue("pose", &pose);
   channel->registerValue("samples", &samples);
-  auto sink = std::make_shared<DataTamer::DummySink>();
+  DataTamerTest::Attached<DataTamer::DummySink> sink;
   channel->addDataSink(sink);
   ASSERT_TRUE(channel->takeSnapshot());
-  sink->flush();
+  sink.drain();
   const auto snapshot = sink->latestSnapshot();
   const auto schema = BuilSchemaFromText(ToStr(channel->getSchema()));
   auto count_values = [](const std::string&, const VarNumber&) {};

--- a/data_tamer_cpp/tests/public_headers_cxx17.cpp
+++ b/data_tamer_cpp/tests/public_headers_cxx17.cpp
@@ -46,6 +46,6 @@ std::string_view TypeDefinition(Probe& p, AddField& add)
   auto logged = channel->createLoggedValue<double>("logged");
   logged->set(1.0);
   auto tx = channel->scopedWrite();
-  channel->addDataSink(std::make_shared<DataTamer::DummySink>());
+  channel->addDataSink(DataTamer::DummySink::create());
 }
 }  // namespace

--- a/data_tamer_cpp/tests/ros2_publisher_tests.cpp
+++ b/data_tamer_cpp/tests/ros2_publisher_tests.cpp
@@ -10,7 +10,7 @@ using namespace DataTamer;
 TEST(DataTamerROS2Publisher, SharedPointer)
 {
   auto node = std::make_shared<rclcpp::Node>("test_datatamer_shared_pointer");
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(node, "test_shared_pointer");
+  auto ros2_sink = ROS2PublisherSink::create(node, "test_shared_pointer");
 
   auto channel = ChannelsRegistry::Global().getChannel("channel_shared_pointer");
 
@@ -29,9 +29,9 @@ TEST(DataTamerROS2Publisher, SharedPointerLifeCycle)
                                                                           "shared_"
                                                                           "pointer_"
                                                                           "lifecycle");
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(lifecycle_node, "test_shared_"
-                                                                       "pointer_"
-                                                                       "lifecycle");
+  auto ros2_sink = ROS2PublisherSink::create(lifecycle_node, "test_shared_"
+                                                             "pointer_"
+                                                             "lifecycle");
 
   auto channel = ChannelsRegistry::Global().getChannel("channel_shared_pointer_"
                                                        "lifecycle");
@@ -49,7 +49,7 @@ TEST(DataTamerROS2Publisher, SharedPointerLifeCycle)
 TEST(DataTamerROS2Publisher, Dereference)
 {
   auto node = std::make_shared<rclcpp::Node>("test_datatamer_dereference");
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(*node, "test_dereference");
+  auto ros2_sink = ROS2PublisherSink::create(*node, "test_dereference");
 
   auto channel = ChannelsRegistry::Global().getChannel("channel_dereference");
 
@@ -67,9 +67,9 @@ TEST(DataTamerROS2Publisher, DereferenceLifeCycle)
                                                                           "datatamer_"
                                                                           "dereference_"
                                                                           "lifecycle");
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(*lifecycle_node, "test_"
-                                                                        "dereference_"
-                                                                        "lifecycle");
+  auto ros2_sink = ROS2PublisherSink::create(*lifecycle_node, "test_"
+                                                              "dereference_"
+                                                              "lifecycle");
 
   auto channel = ChannelsRegistry::Global().getChannel("channel_dereference_lifecycle");
 
@@ -87,8 +87,8 @@ TEST(DataTamerROS2Publisher, NodeInterfacesDirect)
 {
   auto node = std::make_shared<rclcpp::Node>("test_datatamer_node_interfaces");
   PublisherNodeInterfaces interfaces(*node);
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(interfaces, "test_node_"
-                                                                   "interfaces");
+  auto ros2_sink = ROS2PublisherSink::create(interfaces, "test_node_"
+                                                         "interfaces");
 
   auto channel = ChannelsRegistry::Global().getChannel("channel_node_interfaces");
 
@@ -108,8 +108,8 @@ TEST(DataTamerROS2Publisher, NodeInterfacesDirectLifeCycle)
                                                                           "interfaces_"
                                                                           "lifecycle");
   PublisherNodeInterfaces interfaces(*lifecycle_node);
-  auto ros2_sink = std::make_shared<ROS2PublisherSink>(interfaces, "test_node_interfaces_"
-                                                                   "lifecycle");
+  auto ros2_sink = ROS2PublisherSink::create(interfaces, "test_node_interfaces_"
+                                                         "lifecycle");
 
   auto channel = ChannelsRegistry::Global().getChannel("channel_node_interfaces_"
                                                        "lifecycle");

--- a/data_tamer_cpp/tests/sink_queue_tests.cpp
+++ b/data_tamer_cpp/tests/sink_queue_tests.cpp
@@ -2,6 +2,7 @@
 #include "data_tamer/details/snapshot_pool.hpp"
 #include "data_tamer/sinks/mcap_sink.hpp"
 #include "alloc_counter.hpp"
+#include "test_sinks.hpp"
 
 #include <gtest/gtest.h>
 #include <mcap/reader.hpp>
@@ -14,33 +15,33 @@
 #include <thread>
 
 using namespace DataTamer;
+using DataTamerTest::attach;
+using DataTamerTest::Attached;
+using DataTamerTest::manual;
+using Delivery = SinkWorker::Delivery;
 
 namespace
 {
-class QueueSink : public DataSinkBase
+class QueueSink : public DataSink
 {
 public:
-  explicit QueueSink(size_t capacity = 1024, bool worker = false) : DataSinkBase(capacity)
+  void onSchema(const Schema&) override { ++registrations; }
+  void onSnapshot(const SnapshotRef& snapshot) override
   {
-    if(!worker)
-      stopThread();
+    if(callback)
+      callback(snapshot);
   }
-  ~QueueSink() override { stopThread(); }
-  using DataSinkBase::processQueuedSnapshots;
-  using DataSinkBase::retainSnapshot;
-  using DataSinkBase::startAcceptingSnapshots;
-  using DataSinkBase::stopAcceptingSnapshots;
-  using DataSinkBase::stopThread;
-  void addChannel(const std::string&, const Schema&) override { ++registrations; }
-  bool storeSnapshot(const Snapshot& snapshot) override
-  {
-    return callback ? callback(snapshot) : true;
-  }
-  std::function<bool(const Snapshot&)> callback;
+  std::function<void(const SnapshotRef&)> callback;
   std::atomic<int> registrations{ 0 };
 };
 
-std::shared_ptr<LogChannel> channelWith(const std::shared_ptr<DataSinkBase>& sink,
+Attached<QueueSink> queueSink(size_t capacity = 1024,
+                              Delivery delivery = Delivery::Manual)
+{
+  return attach<QueueSink>(delivery, capacity);
+}
+
+std::shared_ptr<LogChannel> channelWith(const std::shared_ptr<SinkWorker>& sink,
                                         const uint64_t* value,
                                         const std::string& name = "queue_test")
 {
@@ -56,18 +57,16 @@ TEST(SinkQueue, RetainedSnapshotOutlivesChannelAndQueue)
   SnapshotRef retained;
   uint64_t value = 42;
   {
-    auto sink = std::make_shared<QueueSink>();
-    sink->callback = [&](const Snapshot&) {
-      retained = sink->retainSnapshot();
-      return true;
-    };
+    auto sink = queueSink();
+    sink->callback = [&](const SnapshotRef& ref) { retained = ref.clone(); };
     auto channel = channelWith(sink, &value, std::string(128, 'n'));
+    const auto hash = channel->getSchema().hash;
     ASSERT_TRUE(channel->takeSnapshot(std::chrono::nanoseconds(123)));
-    channel.reset();  // Even queued references must own the name.
-    sink->processQueuedSnapshots();
+    channel.reset();  // Queued references must not depend on the channel.
+    sink.drain();
+    EXPECT_EQ(retained->schema_hash, hash);
   }
   ASSERT_TRUE(retained);
-  EXPECT_EQ(retained->channel_name, std::string(128, 'n'));
   EXPECT_EQ(retained->timestamp.count(), 123);
   ASSERT_EQ(retained->payload.size(), sizeof(value));
   uint64_t decoded = 0;
@@ -79,47 +78,44 @@ TEST(SinkQueue, RetainedSnapshotOutlivesChannelAndQueue)
 TEST(SinkQueue, QueueOverflowReleasesFailedFanoutWithoutExhaustingPool)
 {
   uint64_t value = 1;
-  auto small = std::make_shared<QueueSink>(1);
-  auto large = std::make_shared<QueueSink>();
+  auto small = queueSink(1);
+  auto large = queueSink();
   auto channel = channelWith(small, &value);
   channel->addDataSink(small);  // Must keep the existing producer token.
   channel->addDataSink(large);
   int received = 0;
-  large->callback = [&](const Snapshot&) {
-    ++received;
-    return true;
-  };
+  large->callback = [&](const SnapshotRef&) { ++received; };
   for(int i = 0; i < 32; ++i)
     ASSERT_TRUE(channel->takeSnapshot());
   EXPECT_EQ(small->registrations.load(), 1);
-  large->processQueuedSnapshots();
+  large.drain();
   for(int i = 0; i < 160; ++i)
   {
     EXPECT_FALSE(channel->takeSnapshot());
-    large->processQueuedSnapshots();
+    large.drain();
   }
   EXPECT_EQ(received, 192);
   EXPECT_EQ(channel->droppedSnapshots(small), 160u);
   EXPECT_EQ(channel->droppedSnapshots(large), 0u);
   EXPECT_EQ(channel->poolExhausted(), 0u);
-  small->processQueuedSnapshots();
+  small.drain();
   EXPECT_TRUE(channel->takeSnapshot());
+  // Callbacks capture locals declared after the workers: stop before they die.
+  small.worker->stop();
+  large.worker->stop();
 }
 
 TEST(SinkQueue, PoolExhaustionIsSeparateAndRetainedSlotsAreReusable)
 {
   uint64_t value = 1;
-  auto sink = std::make_shared<QueueSink>();
+  auto sink = queueSink();
   auto channel = channelWith(sink, &value);
   std::vector<SnapshotRef> retained;
-  sink->callback = [&](const Snapshot&) {
-    retained.push_back(sink->retainSnapshot());
-    return true;
-  };
+  sink->callback = [&](const SnapshotRef& ref) { retained.push_back(ref.clone()); };
   for(int i = 0; i < 64; ++i)
   {
     ASSERT_TRUE(channel->takeSnapshot());
-    sink->processQueuedSnapshots();
+    sink.drain();
   }
   EXPECT_FALSE(channel->takeSnapshot());
   EXPECT_EQ(channel->poolExhausted(), 1u);
@@ -129,13 +125,14 @@ TEST(SinkQueue, PoolExhaustionIsSeparateAndRetainedSlotsAreReusable)
   EXPECT_TRUE(channel->takeSnapshot());
   channel->removeDataSink(sink);
   EXPECT_FALSE(channel->takeSnapshot());
+  sink.worker->stop();  // delivers the last one while `retained` is still alive
 }
 
 TEST(SinkQueue, FixedPayloadFanoutAndOverflowDoNotAllocate)
 {
   uint64_t value = 1;
-  auto small = std::make_shared<QueueSink>(1);
-  auto large = std::make_shared<QueueSink>();
+  auto small = queueSink(1);
+  auto large = queueSink();
   auto channel = channelWith(small, &value);
   channel->addDataSink(large);
   ASSERT_TRUE(channel->takeSnapshot());  // Creates the pool and registers schemas.
@@ -149,15 +146,15 @@ TEST(SinkQueue, FixedPayloadFanoutAndOverflowDoNotAllocate)
         ++successes;
       else
         ++failures;
-      large->processQueuedSnapshots();
+      large.drain();
     }
-    small->processQueuedSnapshots();
+    small.drain();
     for(int i = 0; i < 100; ++i)
     {
       if(channel->takeSnapshot())
         ++successes;
-      small->processQueuedSnapshots();
-      large->processQueuedSnapshots();
+      small.drain();
+      large.drain();
     }
     allocations = scope.allocations();
     deallocations = scope.deallocations();
@@ -174,18 +171,17 @@ TEST(SinkQueue, ExceptionsReleaseReferencesAndDoNotStopDelivery)
   for(bool worker : { false, true })
   {
     uint64_t value = 1;
-    auto sink = std::make_shared<QueueSink>(1024, worker);
+    auto sink = queueSink(1024, worker ? Delivery::Threaded : Delivery::Manual);
     auto channel = channelWith(sink, &value);
     std::mutex mutex;
     std::condition_variable delivered;
     int calls = 0;
-    sink->callback = [&](const Snapshot&) {
+    sink->callback = [&](const SnapshotRef&) {
       std::lock_guard lock(mutex);
       ++calls;
       delivered.notify_all();
       if(calls % 2)
         throw std::runtime_error("callback failed");
-      return false;  // A false result is not an exception.
     };
     for(int i = 0; i < 160; ++i)
     {
@@ -197,37 +193,37 @@ TEST(SinkQueue, ExceptionsReleaseReferencesAndDoNotStopDelivery)
             delivered.wait_for(lock, std::chrono::seconds(5), [&] { return calls > i; }));
       }
       else
-        sink->processQueuedSnapshots();
+        sink.drain();
     }
-    sink->stopThread();
-    sink->processQueuedSnapshots();
+    sink.worker->stop();
     EXPECT_EQ(calls, 160);
-    EXPECT_EQ(sink->storeErrors(), 80u);
+    EXPECT_EQ(sink.worker->errors(), 80u);
+    EXPECT_EQ(sink.worker->lastError(), "callback failed");
     EXPECT_EQ(channel->poolExhausted(), 0u);
   }
 }
 
 TEST(SinkQueue, WorkerAndManualDrainerSerializeCallbacksAndPreserveProducerOrder)
 {
-  auto sink = std::make_shared<QueueSink>(1024, true);
+  auto sink = queueSink(1024, Delivery::Threaded);
   uint64_t a = 0, b = 0;
   auto first = channelWith(sink, &a, "first");
   auto second = channelWith(sink, &b, "second");
+  const auto first_hash = first->getSchema().hash;
   std::atomic<int> active{ 0 }, overlap{ 0 };
   std::vector<uint64_t> values[2];
-  sink->callback = [&](const Snapshot& snapshot) {
+  sink->callback = [&](const SnapshotRef& snapshot) {
     if(active.fetch_add(1) != 0)
       ++overlap;
     uint64_t value = 0;
-    std::memcpy(&value, snapshot.payload.data(), sizeof(value));
-    values[snapshot.channel_name == "first" ? 0 : 1].push_back(value);
+    std::memcpy(&value, snapshot->payload.data(), sizeof(value));
+    values[snapshot->schema_hash == first_hash ? 0 : 1].push_back(value);
     active.fetch_sub(1);
-    return true;
   };
   std::atomic<bool> done{ false };
   std::thread drainer([&] {
     while(!done)
-      sink->processQueuedSnapshots();
+      sink.drain();
   });
   std::vector<uint64_t> accepted[2];
   std::thread producer([&] {
@@ -241,23 +237,22 @@ TEST(SinkQueue, WorkerAndManualDrainerSerializeCallbacksAndPreserveProducerOrder
   producer.join();
   done = true;
   drainer.join();
-  sink->stopThread();
-  sink->processQueuedSnapshots();
+  sink.worker->stop();
   EXPECT_EQ(overlap.load(), 0);
   EXPECT_EQ(values[0], accepted[0]);
   EXPECT_EQ(values[1], accepted[1]);
 }
 
-TEST(SinkQueue, CloseDuringPublicationDrainsEveryAcceptedSnapshot)
+TEST(SinkQueue, StopDuringPublicationDrainsEveryAcceptedSnapshot)
 {
-  auto sink = std::make_shared<QueueSink>(1024, true);
+  auto sink = queueSink(1024, Delivery::Threaded);
   uint64_t value = 0;
   auto channel = channelWith(sink, &value);
   std::mutex mutex;
   std::condition_variable ready;
   bool entered = false, release = false;
   int stored = 0;
-  sink->callback = [&](const Snapshot&) {
+  sink->callback = [&](const SnapshotRef&) {
     std::unique_lock lock(mutex);
     ++stored;
     if(stored == 1)
@@ -266,7 +261,6 @@ TEST(SinkQueue, CloseDuringPublicationDrainsEveryAcceptedSnapshot)
       ready.notify_all();
       ready.wait(lock, [&] { return release; });
     }
-    return true;
   };
   ASSERT_TRUE(channel->takeSnapshot());
   {
@@ -286,42 +280,62 @@ TEST(SinkQueue, CloseDuringPublicationDrainsEveryAcceptedSnapshot)
   });
   while(!attempted)
     std::this_thread::yield();
-  sink->stopAcceptingSnapshots();  // Must return even though callback is blocked.
+  // stop() closes admission at once, then waits for the blocked callback.
+  std::thread stopper([&] { sink.worker->stop(); });
   publish = false;
   producer.join();
-  EXPECT_FALSE(channel->takeSnapshot());
+  while(channel->takeSnapshot())  // admitted until the close is observed
+    ++accepted;
   {
     std::lock_guard lock(mutex);
     release = true;
   }
   ready.notify_all();
-  sink->stopThread();
-  sink->processQueuedSnapshots();
+  stopper.join();
   EXPECT_EQ(stored, accepted);
-  sink->startAcceptingSnapshots();
+  sink.worker->start();
   EXPECT_TRUE(channel->takeSnapshot());
-  sink->processQueuedSnapshots();
+  sink.drain();
   EXPECT_EQ(stored, accepted + 1);
+  sink.worker->stop();
 }
 
-#ifndef NDEBUG
-TEST(SinkQueueDeathTest, DerivedDestructorMustStopWorker)
+TEST(SinkQueue, WorkerDestructionDeliversQueuedSnapshotsBeforeTheSink)
 {
-  EXPECT_DEATH(
-      {
-        class BrokenSink : public DataSinkBase
-        {
-          void addChannel(const std::string&, const Schema&) override {}
-          bool storeSnapshot(const Snapshot&) override { return true; }
-        } sink;
-      },
-      "stopThread");
+  uint64_t value = 7;
+  int delivered = 0;
+  bool destroyed = false;
+  struct Observer : DataSink
+  {
+    int& delivered;
+    bool& destroyed;
+    Observer(int& d, bool& x) : delivered(d), destroyed(x) {}
+    ~Observer() override { destroyed = true; }
+    void onSchema(const Schema&) override {}
+    void onSnapshot(const SnapshotRef&) override
+    {
+      EXPECT_FALSE(destroyed);
+      ++delivered;
+    }
+  };
+  auto channel = LogChannel::create("observer");
+  channel->registerValue("value", &value);
+  {
+    auto sink = manual<Observer>(delivered, destroyed);
+    channel->addDataSink(sink);
+    for(int i = 0; i < 5; ++i)
+      ASSERT_TRUE(channel->takeSnapshot());
+    channel->removeDataSink(sink);
+  }
+  EXPECT_TRUE(destroyed);
+  EXPECT_EQ(delivered, 5);
 }
-#endif
 
 TEST(SinkQueue, ConstructorExceptionPropagates)
 {
-  EXPECT_THROW(MCAPSink("/nonexistent/data_tamer_parent/file.mcap"), std::runtime_error);
+  EXPECT_THROW(MCAPSink::create("/nonexistent/data_tamer_parent/file.mcap"),
+               std::runtime_error);
+  EXPECT_THROW(SinkWorker(nullptr), std::invalid_argument);
 }
 
 TEST(SinkQueue, McapFinalizationWritesEveryAcceptedSnapshotAfterRestart)
@@ -334,18 +348,24 @@ TEST(SinkQueue, McapFinalizationWritesEveryAcceptedSnapshotAfterRestart)
   const auto first = (directory / "first.mcap").string();
   const auto second = (directory / "second.mcap").string();
   uint64_t value = 9;
-  auto sink = std::make_shared<MCAPSink>(first, true, 1);
+  auto sink = attach<MCAPSink>(Delivery::Threaded, 1, first, true);
   auto channel = channelWith(sink, &value);
   for(const auto& path : { first, second })
   {
     if(path == second)
+    {
       sink->restartRecording(path, true);
+      sink.worker->start();
+    }
     size_t accepted = 0;
     for(int i = 0; i < 1000; ++i)
       if(channel->takeSnapshot())
         ++accepted;
-    sink->finishQueueAndStop();
-    sink->finishQueueAndStop();  // stopping twice must be harmless
+    for(int repeat = 0; repeat < 2; ++repeat)  // stopping twice must be harmless
+    {
+      sink.worker->stop();
+      sink->stopRecording();
+    }
     EXPECT_FALSE(channel->takeSnapshot());
     mcap::McapReader reader;
     ASSERT_TRUE(reader.open(path).ok());
@@ -363,29 +383,21 @@ TEST(SinkQueue, McapFinalizationWritesEveryAcceptedSnapshotAfterRestart)
 
 TEST(SinkQueue, McapAutomaticRolloverDoesNotReopenClosedAcceptance)
 {
-  class ControlledMcap : public MCAPSink
-  {
-  public:
-    explicit ControlledMcap(const std::string& path) : MCAPSink(path) { stopThread(); }
-    using DataSinkBase::processQueuedSnapshots;
-    using DataSinkBase::stopAcceptingSnapshots;
-  };
   const auto directory =
       std::filesystem::temp_directory_path() /
       ("data_tamer_rollover_" + std::to_string(NsecSinceEpoch().count()));
   std::filesystem::remove_all(directory);
   ASSERT_TRUE(std::filesystem::create_directory(directory));
   uint64_t value = 1;
-  auto sink = std::make_shared<ControlledMcap>((directory / "rollover.mcap").string());
+  auto sink = manual<MCAPSink>((directory / "rollover.mcap").string());
   sink->setCreateNewFileOnReset(true);
   sink->setMaxTimeBeforeReset(std::chrono::seconds(-1));  // Every callback rolls over.
   auto channel = channelWith(sink, &value);
   for(int i = 0; i < 8; ++i)
     ASSERT_TRUE(channel->takeSnapshot());
-  sink->stopAcceptingSnapshots();
-  sink->processQueuedSnapshots();
+  sink.worker->stop();  // delivers the 8, each one rolling the file over
   EXPECT_FALSE(channel->takeSnapshot());
-  sink->finishQueueAndStop();
+  sink->stopRecording();
   size_t count = 0;
   for(const auto& file : std::filesystem::directory_iterator(directory))
   {
@@ -404,29 +416,26 @@ TEST(SinkQueue, McapAutomaticRolloverDoesNotReopenClosedAcceptance)
 TEST(SinkQueue, FastConsumerCannotReleaseParentBeforeSecondFanout)
 {
   uint64_t value = 0;
-  auto first = std::make_shared<QueueSink>(1024, true);
-  auto second = std::make_shared<QueueSink>(1024, true);
+  auto first = queueSink(1024, Delivery::Threaded);
+  auto second = queueSink(1024, Delivery::Threaded);
   auto channel = channelWith(first, &value);
   channel->addDataSink(second);
   channel->setPoolCapacity(2);
   std::vector<uint64_t> received[2];
   for(int i = 0; i < 2; ++i)
   {
-    auto sink = i == 0 ? first : second;
-    sink->callback = [&, i](const Snapshot& snapshot) {
+    auto& sink = i == 0 ? first : second;
+    sink->callback = [&, i](const SnapshotRef& snapshot) {
       uint64_t decoded = 0;
-      std::memcpy(&decoded, snapshot.payload.data(), sizeof(decoded));
+      std::memcpy(&decoded, snapshot->payload.data(), sizeof(decoded));
       received[i].push_back(decoded);
-      return true;
     };
   }
   size_t accepted = 0;
   for(value = 0; value < 10000; ++value)
     accepted += channel->takeSnapshot();
-  first->stopThread();
-  second->stopThread();
-  first->processQueuedSnapshots();
-  second->processQueuedSnapshots();
+  first.worker->stop();
+  second.worker->stop();
   EXPECT_GT(accepted, 0u);
   EXPECT_EQ(channel->droppedSnapshots(first), 0u);
   EXPECT_EQ(channel->droppedSnapshots(second), 0u);
@@ -445,14 +454,15 @@ TEST(SinkQueue, McapFailedRestartKeepsTheCurrentRecording)
   ASSERT_TRUE(std::filesystem::create_directory(directory));
   const auto path = (directory / "log.mcap").string();
   uint64_t value = 3;
-  auto sink = std::make_shared<MCAPSink>(path, false);
+  Attached<MCAPSink> sink(path, false);
   auto channel = channelWith(sink, &value);
   ASSERT_TRUE(channel->takeSnapshot());
   EXPECT_THROW(
       sink->restartRecording((directory / "missing" / "dir" / "x.mcap").string()),
       std::runtime_error);
   ASSERT_TRUE(channel->takeSnapshot());  // still recording into the first file
-  sink->finishQueueAndStop();
+  sink.worker->stop();
+  sink->stopRecording();
   mcap::McapReader reader;
   ASSERT_TRUE(reader.open(path).ok());
   size_t count = 0;

--- a/data_tamer_cpp/tests/snapshot_pool_tests.cpp
+++ b/data_tamer_cpp/tests/snapshot_pool_tests.cpp
@@ -14,7 +14,8 @@ using DataTamerTest::AllocCounter;
 
 static std::shared_ptr<SnapshotPool> makePool(size_t capacity = 4)
 {
-  return std::make_shared<SnapshotPool>(capacity, /*payload_capacity=*/256, /*mask_bytes=*/2);
+  return std::make_shared<SnapshotPool>(capacity, /*payload_capacity=*/256,
+                                        /*mask_bytes=*/2);
 }
 
 TEST(SnapshotPool, SlotsArePreallocated)
@@ -202,17 +203,6 @@ TEST(SnapshotPool, ProducerAndConsumersUnderContention)
   ASSERT_EQ(consumed.load(), produced * kConsumers);
   ASSERT_EQ(pool->inUse(), 0u);
   ASSERT_EQ(pool->exhausted(), uint64_t(dropped));
-}
-
-TEST(SnapshotPool, OwnsChannelNameBeyondSourceLifetime)
-{
-  SnapshotRef survivor;
-  {
-    std::string name(128, 'x');
-    auto pool = std::make_shared<SnapshotPool>(1, 8, 1, name);
-    survivor = SnapshotRef(pool, pool->tryAcquire());
-  }
-  EXPECT_EQ(survivor->channel_name, std::string(128, 'x'));
 }
 
 TEST(SnapshotPool, ParentPinsSlotBetweenCompletedAndPendingFanout)

--- a/data_tamer_cpp/tests/test_sinks.hpp
+++ b/data_tamer_cpp/tests/test_sinks.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "data_tamer/data_sink.hpp"
+
+#include <memory>
+#include <utility>
+
+namespace DataTamerTest
+{
+
+/// A SinkWorker owning a T, with direct access to the T. Converts to the
+/// shared_ptr<SinkWorker> that LogChannel::addDataSink takes.
+template <typename T>
+struct Attached
+{
+  explicit Attached(std::shared_ptr<DataTamer::SinkWorker> worker_)
+    : worker(std::move(worker_)), sink(&worker->template as<T>())
+  {}
+
+  template <typename... Args>
+  explicit Attached(Args&&... args)
+    : Attached(DataTamer::SinkWorker::create<T>(std::forward<Args>(args)...))
+  {}
+
+  T* operator->() const { return sink; }
+  T& operator*() const { return *sink; }
+  operator const std::shared_ptr<DataTamer::SinkWorker>&() const { return worker; }
+
+  /// Deliver everything queued so far on this thread (see SinkWorker::drain).
+  void drain() const { worker->drain(); }
+
+  std::shared_ptr<DataTamer::SinkWorker> worker;
+  T* sink;
+};
+
+/// Worker with an explicit delivery mode and queue capacity. Manual delivery
+/// makes tests deterministic: snapshots are delivered only by drain().
+template <typename T, typename... Args>
+Attached<T> attach(DataTamer::SinkWorker::Delivery delivery,
+                   size_t capacity = DataTamer::SinkWorker::kDefaultQueueCapacity,
+                   Args&&... args)
+{
+  return Attached<T>(std::make_shared<DataTamer::SinkWorker>(
+      std::make_unique<T>(std::forward<Args>(args)...), capacity, delivery));
+}
+
+template <typename T, typename... Args>
+Attached<T> manual(Args&&... args)
+{
+  return Attached<T>(std::make_shared<DataTamer::SinkWorker>(
+      std::make_unique<T>(std::forward<Args>(args)...),
+      DataTamer::SinkWorker::kDefaultQueueCapacity,
+      DataTamer::SinkWorker::Delivery::Manual));
+}
+
+}  // namespace DataTamerTest

--- a/data_tamer_cpp/tests/transaction_tests.cpp
+++ b/data_tamer_cpp/tests/transaction_tests.cpp
@@ -1,5 +1,6 @@
 #include "data_tamer/data_tamer.hpp"
 #include "alloc_counter.hpp"
+#include "test_sinks.hpp"
 #include "wait_for_sleeping_thread.hpp"
 
 #include <gtest/gtest.h>
@@ -26,7 +27,7 @@ using DataTamerTest::AllocCounter;
 
 namespace
 {
-class CheckingSink : public DataSinkBase
+class CheckingSink : public DataSink
 {
 public:
   enum class Payload
@@ -36,9 +37,8 @@ public:
   };
 
   explicit CheckingSink(Payload payload) : payload_(payload) {}
-  ~CheckingSink() override { stopThread(); }
 
-  void addChannel(const std::string&, const Schema&) override {}
+  void onSchema(const Schema&) override {}
 
   bool waitFor(size_t count)
   {
@@ -60,8 +60,9 @@ public:
   }
 
 protected:
-  bool storeSnapshot(const Snapshot& snapshot) override
+  void onSnapshot(const SnapshotRef& ref) override
   {
+    const Snapshot& snapshot = *ref;
     bool valid = false;
     if(payload_ == Payload::PAIR && snapshot.payload.size() == 2 * sizeof(double))
     {
@@ -91,7 +92,6 @@ protected:
       errors_ += !valid;
     }
     delivered_.notify_all();
-    return true;
   }
 
 private:
@@ -275,7 +275,7 @@ void raceWriterAgainstSnapshots(LogChannel& channel, CheckingSink& sink,
 TEST(Transaction, ValuesWrittenTogetherAppearTogetherInDeliveredSnapshots)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<CheckingSink>(CheckingSink::Payload::PAIR);
+  DataTamerTest::Attached<CheckingSink> sink(CheckingSink::Payload::PAIR);
   channel->addDataSink(sink);
   auto a = channel->createLoggedValue<double>("a", 1.0);
   auto b = channel->createLoggedValue<double>("b", 1.0);
@@ -293,7 +293,7 @@ TEST(Transaction, ValuesWrittenTogetherAppearTogetherInDeliveredSnapshots)
 TEST(Transaction, RawPointerWritesAppearTogetherInDeliveredSnapshots)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<CheckingSink>(CheckingSink::Payload::PAIR);
+  DataTamerTest::Attached<CheckingSink> sink(CheckingSink::Payload::PAIR);
   channel->addDataSink(sink);
   Pair pair{ 1.0, 1.0 };
   channel->registerValue("pair", &pair);
@@ -311,7 +311,7 @@ TEST(Transaction, RawPointerWritesAppearTogetherInDeliveredSnapshots)
 TEST(Transaction, VectorSetAndSnapshotRaceDeliversValidPayloads)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<CheckingSink>(CheckingSink::Payload::VECTOR);
+  DataTamerTest::Attached<CheckingSink> sink(CheckingSink::Payload::VECTOR);
   channel->addDataSink(sink);
   auto vec = channel->createLoggedValue<std::vector<double>>("vec");
 
@@ -325,7 +325,7 @@ TEST(Transaction, VectorSetAndSnapshotRaceDeliversValidPayloads)
 TEST(Transaction, ContentionCountersReportSnapshotHandoffAndRemainStableWhenUncontended)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<CheckingSink>(CheckingSink::Payload::PAIR);
+  DataTamerTest::Attached<CheckingSink> sink(CheckingSink::Payload::PAIR);
   channel->addDataSink(sink);
   auto a = channel->createLoggedValue<double>("a", 1.0);
   auto b = channel->createLoggedValue<double>("b", 1.0);
@@ -371,7 +371,7 @@ TEST(Transaction, ObservedSleepingSnapshotAdvancesContentionCounters)
   if(!std::ifstream("/proc/self/stat"))
     GTEST_SKIP() << "needs readable procfs";
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<CheckingSink>(CheckingSink::Payload::PAIR);
+  DataTamerTest::Attached<CheckingSink> sink(CheckingSink::Payload::PAIR);
   channel->addDataSink(sink);
   auto a = channel->createLoggedValue<double>("a", 1.0);
   auto b = channel->createLoggedValue<double>("b", 1.0);
@@ -416,7 +416,7 @@ TEST(Transaction, LoneScalarSetDoesNotTakeWriteMutex)
 TEST(Transaction, DisabledAndDestroyedValuesAreNotSized)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<CheckingSink>(CheckingSink::Payload::VECTOR);
+  DataTamerTest::Attached<CheckingSink> sink(CheckingSink::Payload::VECTOR);
   channel->addDataSink(sink);
   CustomValue value;
   auto serializer = std::make_shared<ProbeSerializer>();
@@ -438,7 +438,7 @@ TEST(Transaction, DisabledAndDestroyedValuesAreNotSized)
 TEST(Transaction, SerializationExceptionReleasesWriteMutex)
 {
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<CheckingSink>(CheckingSink::Payload::VECTOR);
+  DataTamerTest::Attached<CheckingSink> sink(CheckingSink::Payload::VECTOR);
   channel->addDataSink(sink);
   CustomValue value;
   auto serializer = std::make_shared<ProbeSerializer>();
@@ -458,7 +458,7 @@ TEST(Transaction, ValuesEnabledInsideATransactionAppearTogether)
   if(!std::ifstream("/proc/self/stat"))
     GTEST_SKIP() << "needs readable procfs";
   auto channel = LogChannel::create("chan");
-  auto sink = std::make_shared<CheckingSink>(CheckingSink::Payload::PAIR);
+  DataTamerTest::Attached<CheckingSink> sink(CheckingSink::Payload::PAIR);
   channel->addDataSink(sink);
   auto a = channel->createLoggedValue<double>("a", 1.0);
   auto b = channel->createLoggedValue<double>("b", 1.0);

--- a/data_tamer_cpp/tests/wire_format_tests.cpp
+++ b/data_tamer_cpp/tests/wire_format_tests.cpp
@@ -7,6 +7,7 @@
 #include "data_tamer/data_tamer.hpp"
 #include "data_tamer/sinks/dummy_sink.hpp"
 #include "data_tamer/sinks/mcap_sink.hpp"
+#include "test_sinks.hpp"
 #include "../examples/geometry_types.hpp"
 
 #include <mcap/reader.hpp>
@@ -41,17 +42,6 @@ std::string_view TypeDefinition(StampedPose& p, AddField& add)
   return "Pose";
 }
 
-// Sinks without a worker thread, so delivery happens exactly when the test drains
-// them: no race between the worker and finishQueueAndStop(), deterministic order.
-struct SyncSink : DummySink
-{
-  SyncSink() { stopThread(); }
-};
-struct SyncMcap : MCAPSink
-{
-  explicit SyncMcap(const std::string& path) : MCAPSink(path, false) { stopThread(); }
-};
-
 const std::string kDir = DATA_TAMER_WIRE_FORMAT_DIR;
 
 std::vector<uint8_t> readFile(const std::string& name)
@@ -85,8 +75,9 @@ TEST(WireFormat, SchemaTextAndSnapshotsMatchGoldenVectors)
        ("data_tamer_wire_format_" + std::to_string(::getpid()) + ".mcap"))
           .string();
   auto channel = LogChannel::create("wire_test");
-  auto sink = std::make_shared<SyncSink>();
-  auto mcap = std::make_shared<SyncMcap>(mcap_path);
+  // Manual delivery: snapshots reach the sinks exactly when the test drains them.
+  auto sink = DataTamerTest::manual<DummySink>();
+  auto mcap = DataTamerTest::manual<MCAPSink>(mcap_path, false);
   channel->addDataSink(sink);
   channel->addDataSink(mcap);
 
@@ -130,7 +121,7 @@ TEST(WireFormat, SchemaTextAndSnapshotsMatchGoldenVectors)
 
   const std::chrono::nanoseconds stamp(1234567890);
   ASSERT_TRUE(channel->takeSnapshot(stamp));
-  sink->flush();
+  sink.drain();
   const Snapshot full = sink->latestSnapshot();
 
   const std::string schema_text = ToStr(channel->getSchema());
@@ -144,13 +135,14 @@ TEST(WireFormat, SchemaTextAndSnapshotsMatchGoldenVectors)
   channel->setEnabled(id_i16, false);
   channel->setEnabled(id_pose, false);
   ASSERT_TRUE(channel->takeSnapshot(stamp));
-  sink->flush();
+  sink.drain();
   const Snapshot masked = sink->latestSnapshot();
   checkGolden("snapshot_masked.mask", masked.active_mask);
   checkGolden("snapshot_masked.payload", masked.payload);
 
   // The MCAP records MCAPSink actually wrote: schema, channel and message bodies.
-  mcap->finishQueueAndStop();
+  mcap.worker->stop();
+  mcap->stopRecording();
   mcap::McapReader reader;
   ASSERT_TRUE(reader.open(mcap_path).ok());
   std::vector<std::vector<uint8_t>> bodies;


### PR DESCRIPTION
Sink side of the "snapshot and sink contract" bucket from the V2 review (#85, items 25, 26, 27 and 14), in the reduced form recommended by a second review. The channel side (`prepare()`, `SnapshotResult`, `tryTakeSnapshot()`; items 28 and 29) follows in a separate PR.

## Composition instead of `DataSinkBase` (item 26)

`DataSinkBase` owned the worker thread and called derived virtuals from it, so every derived destructor had to remember `stopThread()` and the base destructor could only detect the mistake after the fact. It is replaced by two classes:

- `DataSink`: the interface a sink implements. Two protected virtuals, `onSchema(const Schema&)` and `onSnapshot(const SnapshotRef&)`. Throw from `onSnapshot` to report a failure.
- `SinkWorker`: owns the `DataSink`, the queue and the delivery thread, and is what `LogChannel::addDataSink` takes. It stops the worker before destroying the sink, so ordering is enforced once. Its destructor also delivers what is still queued.

The four lifecycle calls (`stopThread`, `stopAcceptingSnapshots`, `processQueuedSnapshots`, `startAcceptingSnapshots`) collapse to `stop()`, `start()` and `drain()`. `Delivery::Manual` runs without a thread for applications that deliver from their own loop (and makes tests deterministic).

Convenience for the common path, as requested: `MCAPSink::create(path)`, `ROS2PublisherSink::create(node, prefix)`, `DummySink::create()` and the generic `SinkWorker::create<T>(args...)` return a ready-to-attach worker. `worker->as<MCAPSink>()` reaches the sink's own methods.

## Callback contract (item 27)

Delivery callbacks are non-public on every sink (`protected` + `friend SinkWorker`), so nothing can bypass the queue. `onSchema` and `onSnapshot` are serialized by the worker's store mutex, so a sink needs no lock for the state they touch: the ROS sink's schema mutex is gone. The contract is documented on `DataSink` in three sentences: which thread, what is serialized, never call channel control methods from a callback. Releasing the channel control lock around `onSchema` is left to the `prepare()` PR, where the freeze logic moves.

## Snapshot ownership (item 25)

`Snapshot::channel_name` is deleted. It was the only borrowed field (a `string_view` into the channel), nothing needed it (the schema hash covers the channel name, `Schema::channel_name` has it), and without it `Snapshot` is fully owning: a copy is an independent record. `SnapshotRef` moves from the pool header into `data_sink.hpp` as an opaque move-only handle with out-of-line methods; the callback receives it directly and `ref.clone()` retains it. `retainSnapshot()` and its thread-local context are gone, and no private header is needed to keep a snapshot.

## Error reporting (item 14)

`MCAPSink` throws on a failed write. `SinkWorker::errors()` counts callback exceptions and `lastError()` keeps the last message. One mechanism for every sink instead of a per-sink status API. `MCAPSink::finishQueueAndStop()` is now `worker->stop(); mcap.stopRecording();` and `restartRecording()` no longer touches admission (call `worker->start()` after a stop).

## Tests

Every custom test sink and the benchmarks' `NullSink`/`LatencySink` are `DataSink`s. `tests/test_sinks.hpp` pairs a worker with typed access for the tests. New: `WorkerDestructionDeliversQueuedSnapshotsBeforeTheSink`. Removed: the death test for a forgotten `stopThread()` (the mistake is no longer possible) and the pool test for owned channel names (the field is gone). ABI test covers `SinkWorker` and `SnapshotRef` sizes.

## Verification

- Debug, ASAN/UBSAN, TSAN: 137/137 (+ Python decoder), examples run, `mcap info` reads the example output.
- ROS 2 lyrical colcon build with examples: see comment below.
- Loaded stress: see comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
